### PR TITLE
Remove duplicate `cache_options` option docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,6 @@ id_method_name | Set custom method name to get ID of an object | ```has_many :lo
 object_method_name | Set custom method name to get related objects | ```has_many :locations, object_method_name: :places ```
 record_type | Set custom Object Type for a relationship | ```belongs_to :owner, record_type: :user```
 serializer | Set custom Serializer for a relationship | ```has_many :actors, serializer: :custom_actor```
-cache_options | Hash to enable caching and set cache length | ```cache_options enabled: true cache_length: 12.hours ```
 
 
 ## Contributing


### PR DESCRIPTION
This same entry already exists higher up in the table.