### PR TITLE
Use `File.exist?` instead of `File.exists?`

### DIFF
--- a/spec/lib/extensions/active_record_spec.rb
+++ b/spec/lib/extensions/active_record_spec.rb
@@ -62,6 +62,6 @@ describe 'active record' do
 
   # Clean up DB
   after(:all) do
-    File.delete(@db_file) if File.exists?(@db_file)
+    File.delete(@db_file) if File.exist?(@db_file)
   end
 end


### PR DESCRIPTION
File.exists? is deprecated in Ruby 2.1+
Ref: https://github.com/ruby/ruby/blob/v2_1_2/file.c#L1413