### PR TITLE
use travis env to exclude perf test while building

### DIFF
--- a/spec/lib/object_serializer_performance_spec.rb
+++ b/spec/lib/object_serializer_performance_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe FastJsonapi::ObjectSerializer do
+describe FastJsonapi::ObjectSerializer, performance: true do
   include_context 'movie class'
   include_context 'ams movie class'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,9 @@ Dir[File.dirname(__FILE__) + '/shared/contexts/*.rb'].each {|file| require file 
 
 RSpec.configure do |config|
   config.include RSpec::Benchmark::Matchers
+  if ENV['TRAVIS'] == 'true' || ENV['TRAVIS'] == true
+    config.filter_run_excluding performance: true
+  end
 end
 
 ActiveModel::Serializer.config.adapter = :json_api


### PR DESCRIPTION
Differences in resource running the performance test can result in variation.