### PR TITLE
add hash benchmarking to performance tests

### DIFF
--- a/spec/lib/object_serializer_performance_spec.rb
+++ b/spec/lib/object_serializer_performance_spec.rb
@@ -34,12 +34,28 @@ describe FastJsonapi::ObjectSerializer, performance: true do
     end
   end
 
-  def print_stats(count, ams_time, our_time)
+  def print_stats(message, count, ams_time, our_time)
     format = '%-15s %-10s %s'
     puts ''
+    puts message
     puts format(format, 'Serializer', 'Records', 'Time')
     puts format(format, 'AMS serializer', count, ams_time.round(2).to_s + ' ms')
     puts format(format, 'Fast serializer', count, our_time.round(2).to_s + ' ms')
+  end
+
+  def run_hash_benchmark(message, movie_count, our_serializer, ams_serializer)
+    our_time = Benchmark.measure { our_hash = our_serializer.serializable_hash }.real * 1000
+    ams_time = Benchmark.measure { ams_hash = ams_serializer.as_json }.real * 1000
+    print_stats(message, movie_count, ams_time, our_time)
+  end
+
+  def run_json_benchmark(message, movie_count, our_serializer, ams_serializer)
+    our_json = nil
+    ams_json = nil
+    our_time = Benchmark.measure { our_json = our_serializer.serialized_json }.real * 1000
+    ams_time = Benchmark.measure { ams_json = ams_serializer.to_json }.real * 1000
+    print_stats(message, movie_count, ams_time, our_time)
+    return our_json, ams_json
   end
 
   context 'when comparing with AMS 0.10.x' do
@@ -48,15 +64,18 @@ describe FastJsonapi::ObjectSerializer, performance: true do
       it "should serialize #{movie_count} records atleast #{speed_factor} times faster than AMS" do
         ams_movies = build_ams_movies(movie_count)
         movies = build_movies(movie_count)
-        our_json = nil
-        ams_json = nil
         our_serializer = MovieSerializer.new(movies)
         ams_serializer = ActiveModelSerializers::SerializableResource.new(ams_movies)
-        our_time = Benchmark.measure { our_json = our_serializer.serialized_json }.real * 1000
-        ams_time = Benchmark.measure { ams_json = ams_serializer.to_json }.real * 1000
-        print_stats(movie_count, ams_time, our_time)
+
+        message = "Serialize to JSON string #{movie_count} records"
+        our_json, ams_json = run_json_benchmark(message, movie_count, our_serializer, ams_serializer)
+
+        message = "Serialize to Ruby Hash #{movie_count} records"
+        run_hash_benchmark(message, movie_count, our_serializer, ams_serializer)
+
         expect(our_json.length).to eq ams_json.length
         expect { our_serializer.serialized_json }.to perform_faster_than { ams_serializer.to_json }.at_least(speed_factor).times
+        expect { our_serializer.serializable_hash }.to perform_faster_than { ams_serializer.as_json }.at_least(speed_factor).times
       end
     end
   end
@@ -67,20 +86,21 @@ describe FastJsonapi::ObjectSerializer, performance: true do
       it "should serialize #{movie_count} records atleast #{speed_factor} times faster than AMS" do
         ams_movies = build_ams_movies(movie_count)
         movies = build_movies(movie_count)
-        our_json = nil
-        ams_json = nil
-
         options = {}
         options[:meta] = { total: movie_count }
         options[:include] = [:actors, :movie_type]
-
         our_serializer = MovieSerializer.new(movies, options)
         ams_serializer = ActiveModelSerializers::SerializableResource.new(ams_movies, include: options[:include], meta: options[:meta])
-        our_time = Benchmark.measure { our_json = our_serializer.serialized_json }.real * 1000
-        ams_time = Benchmark.measure { ams_json = ams_serializer.to_json }.real * 1000
-        print_stats(movie_count, ams_time, our_time)
+
+        message = "Serialize to JSON string #{movie_count} with includes and meta"
+        our_json, ams_json = run_json_benchmark(message, movie_count, our_serializer, ams_serializer)
+
+        message = "Serialize to Ruby Hash #{movie_count} with includes and meta"
+        run_hash_benchmark(message, movie_count, our_serializer, ams_serializer)
+
         expect(our_json.length).to eq ams_json.length
         expect { our_serializer.serialized_json }.to perform_faster_than { ams_serializer.to_json }.at_least(speed_factor).times
+        expect { our_serializer.serializable_hash }.to perform_faster_than { ams_serializer.as_json }.at_least(speed_factor).times
       end
     end
   end


### PR DESCRIPTION
I tweaked the performance tests to generate just a ruby hash using both the libraries. This helps demonstrate the performance difference without any involvement of OJ. As OJ is only used in both libraries to convert the ruby hash to a JSON string.

Here is the benchmark output i get when i run these tests

```
Serialize to JSON string 1 records
Serializer      Records    Time
AMS serializer  1          3.21 ms
Fast serializer 1          0.17 ms

Serialize to Ruby Hash 1 records
Serializer      Records    Time
AMS serializer  1          0.7 ms
Fast serializer 1          0.04 ms
.
Serialize to JSON string 25 records
Serializer      Records    Time
AMS serializer  25         16.35 ms
Fast serializer 25         0.6 ms

Serialize to Ruby Hash 25 records
Serializer      Records    Time
AMS serializer  25         10.25 ms
Fast serializer 25         0.28 ms
.
Serialize to JSON string 250 records
Serializer      Records    Time
AMS serializer  250        143.51 ms
Fast serializer 250        3.44 ms

Serialize to Ruby Hash 250 records
Serializer      Records    Time
AMS serializer  250        98.55 ms
Fast serializer 250        2.17 ms
.
Serialize to JSON string 1000 records
Serializer      Records    Time
AMS serializer  1000       556.1 ms
Fast serializer 1000       14.3 ms

Serialize to Ruby Hash 1000 records
Serializer      Records    Time
AMS serializer  1000       367.52 ms
Fast serializer 1000       9.35 ms
.
Serialize to JSON string 1 with includes and meta
Serializer      Records    Time
AMS serializer  1          1.85 ms
Fast serializer 1          0.13 ms

Serialize to Ruby Hash 1 with includes and meta
Serializer      Records    Time
AMS serializer  1          1.2 ms
Fast serializer 1          0.05 ms
.
Serialize to JSON string 25 with includes and meta
Serializer      Records    Time
AMS serializer  25         17.02 ms
Fast serializer 25         0.49 ms

Serialize to Ruby Hash 25 with includes and meta
Serializer      Records    Time
AMS serializer  25         11.98 ms
Fast serializer 25         2.11 ms
.
Serialize to JSON string 250 with includes and meta
Serializer      Records    Time
AMS serializer  250        159.24 ms
Fast serializer 250        7.65 ms

Serialize to Ruby Hash 250 with includes and meta
Serializer      Records    Time
AMS serializer  250        119.94 ms
Fast serializer 250        3.87 ms
.
Serialize to JSON string 1000 with includes and meta
Serializer      Records    Time
AMS serializer  1000       623.21 ms
Fast serializer 1000       30.67 ms

Serialize to Ruby Hash 1000 with includes and meta
Serializer      Records    Time
AMS serializer  1000       458.59 ms
Fast serializer 1000       27.64 ms

```