### PR TITLE
Add missing attribute in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $ bundle install
 
 ```ruby
 class Movie
-  attr_accessor :id, :name, :year, :actor_ids, :owner_id
+  attr_accessor :id, :name, :year, :actor_ids, :owner_id, :movie_type_id
 end
 ```
 


### PR DESCRIPTION
It seems to me that this `attr_accessor` is missing because it's used later but not mentioned here.