### PR TITLE
Enable OJ and optimize performance test

### DIFF
--- a/spec/lib/object_serializer_performance_spec.rb
+++ b/spec/lib/object_serializer_performance_spec.rb
@@ -4,6 +4,9 @@ describe FastJsonapi::ObjectSerializer, performance: true do
   include_context 'movie class'
   include_context 'ams movie class'
 
+  before(:all) { GC.disable }
+  after(:all) { GC.enable }
+
   context 'when testing performance of serialization' do
     it 'should create a hash of 1000 records in less than 50 ms' do
       movies = 1000.times.map { |_i| movie }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require 'rspec-benchmark'
 require 'multi_json'
 require 'byebug'
 require 'active_model_serializers'
+require 'oj'
 
 Dir[File.dirname(__FILE__) + '/shared/contexts/*.rb'].each {|file| require file }
 
@@ -13,6 +14,7 @@ RSpec.configure do |config|
   end
 end
 
+Oj.optimize_rails
 ActiveModel::Serializer.config.adapter = :json_api
 ActiveModel::Serializer.config.key_transform = :underscore
 ActiveModelSerializers.logger = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new('/dev/null'))


### PR DESCRIPTION
* As mentioned in https://github.com/Netflix/fast_jsonapi/issues/24, it enables OJ for AM.
* Disable GC in performance benchmark