### PR TITLE
Add Primalize gem for performance comparison

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,9 @@ GEM
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
     oj (3.4.0)
-    primalize (0.3.4)
+    primalize (0.3.5)
+    primalize-jsonapi (0.1.2)
+      primalize
     public_suffix (3.0.1)
     rack (2.0.3)
     rack-test (0.8.2)
@@ -148,7 +150,7 @@ DEPENDENCIES
   byebug
   fast_jsonapi!
   juwelier (~> 2.1.0)
-  primalize (~> 0.3.3)
+  primalize-jsonapi (~> 0.1)
   rdoc (~> 3.12)
   rspec (~> 3.5.0)
   rspec-benchmark (~> 0.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,7 @@ GEM
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
     oj (3.4.0)
+    primalize (0.3.4)
     public_suffix (3.0.1)
     rack (2.0.3)
     rack-test (0.8.2)
@@ -147,6 +148,7 @@ DEPENDENCIES
   byebug
   fast_jsonapi!
   juwelier (~> 2.1.0)
+  primalize (~> 0.3.3)
   rdoc (~> 3.12)
   rspec (~> 3.5.0)
   rspec-benchmark (~> 0.3.0)

--- a/fast_jsonapi.gemspec
+++ b/fast_jsonapi.gemspec
@@ -71,7 +71,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<simplecov>, [">= 0"])
       s.add_development_dependency(%q<byebug>, [">= 0"])
       s.add_development_dependency(%q<active_model_serializers>, ["~> 0.10.4"])
-      s.add_development_dependency(%q<primalize>, ["~> 0.3.3"])
+      s.add_development_dependency(%q<primalize-jsonapi>, ["~> 0.1"])
       s.add_development_dependency(%q<sqlite3>, ["~> 1.3"])
     else
       s.add_dependency(%q<activesupport>, ["~> 5.0"])
@@ -87,7 +87,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<simplecov>, [">= 0"])
       s.add_dependency(%q<byebug>, [">= 0"])
       s.add_dependency(%q<active_model_serializers>, ["~> 0.10.4"])
-      s.add_dependency(%q<primalize>, ["~> 0.3.3"])
+      s.add_dependency(%q<primalize-jsonapi>, ["~> 0.1"])
       s.add_dependency(%q<sqlite3>, ["~> 1.3"])
     end
   else
@@ -104,7 +104,7 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<simplecov>, [">= 0"])
     s.add_dependency(%q<byebug>, [">= 0"])
     s.add_dependency(%q<active_model_serializers>, ["~> 0.10.4"])
-    s.add_dependency(%q<primalize>, ["~> 0.3.3"])
+    s.add_dependency(%q<primalize-jsonapi>, ["~> 0.1"])
     s.add_dependency(%q<sqlite3>, ["~> 1.3"])
   end
 end

--- a/fast_jsonapi.gemspec
+++ b/fast_jsonapi.gemspec
@@ -71,6 +71,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<simplecov>, [">= 0"])
       s.add_development_dependency(%q<byebug>, [">= 0"])
       s.add_development_dependency(%q<active_model_serializers>, ["~> 0.10.4"])
+      s.add_development_dependency(%q<primalize>, ["~> 0.3.3"])
       s.add_development_dependency(%q<sqlite3>, ["~> 1.3"])
     else
       s.add_dependency(%q<activesupport>, ["~> 5.0"])
@@ -86,6 +87,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<simplecov>, [">= 0"])
       s.add_dependency(%q<byebug>, [">= 0"])
       s.add_dependency(%q<active_model_serializers>, ["~> 0.10.4"])
+      s.add_dependency(%q<primalize>, ["~> 0.3.3"])
       s.add_dependency(%q<sqlite3>, ["~> 1.3"])
     end
   else
@@ -102,6 +104,7 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<simplecov>, [">= 0"])
     s.add_dependency(%q<byebug>, [">= 0"])
     s.add_dependency(%q<active_model_serializers>, ["~> 0.10.4"])
+    s.add_dependency(%q<primalize>, ["~> 0.3.3"])
     s.add_dependency(%q<sqlite3>, ["~> 1.3"])
   end
 end

--- a/spec/lib/object_serializer_performance_spec.rb
+++ b/spec/lib/object_serializer_performance_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe FastJsonapi::ObjectSerializer, performance: true do
   include_context 'movie class'
   include_context 'ams movie class'
+  include_context 'primalize movie class'
 
   before(:all) { GC.disable }
   after(:all) { GC.enable }
@@ -37,27 +38,31 @@ describe FastJsonapi::ObjectSerializer, performance: true do
     end
   end
 
-  def print_stats(message, count, ams_time, our_time)
-    format = '%-15s %-10s %s'
+  def print_stats(message, count, ams_time, our_time, primalize_time)
+    header = '%-15s %-10s %s'
+    format = '%-15s %-10s %.02f'
     puts ''
     puts message
-    puts format(format, 'Serializer', 'Records', 'Time')
-    puts format(format, 'AMS serializer', count, ams_time.round(2).to_s + ' ms')
-    puts format(format, 'Fast serializer', count, our_time.round(2).to_s + ' ms')
+    puts format(header, 'Serializer', 'Records', 'Time')
+    puts format(format, 'AMS serializer', count, ams_time)
+    puts format(format, 'Fast serializer', count, our_time)
+    puts format(format, 'Primalize', count, primalize_time)
   end
 
-  def run_hash_benchmark(message, movie_count, our_serializer, ams_serializer)
+  def run_hash_benchmark(message, movie_count, our_serializer, ams_serializer, primalize_serializer)
     our_time = Benchmark.measure { our_hash = our_serializer.serializable_hash }.real * 1000
     ams_time = Benchmark.measure { ams_hash = ams_serializer.as_json }.real * 1000
-    print_stats(message, movie_count, ams_time, our_time)
+    primalize_time = Benchmark.measure { primalize_serializer.as_json }.real * 1000
+    print_stats(message, movie_count, ams_time, our_time, primalize_time)
   end
 
-  def run_json_benchmark(message, movie_count, our_serializer, ams_serializer)
+  def run_json_benchmark(message, movie_count, our_serializer, ams_serializer, primalize_serializer)
     our_json = nil
     ams_json = nil
     our_time = Benchmark.measure { our_json = our_serializer.serialized_json }.real * 1000
     ams_time = Benchmark.measure { ams_json = ams_serializer.to_json }.real * 1000
-    print_stats(message, movie_count, ams_time, our_time)
+    primalize_time = Benchmark.measure { primalize_serializer.to_json }.real * 1000
+    print_stats(message, movie_count, ams_time, our_time, primalize_time)
     return our_json, ams_json
   end
 
@@ -69,12 +74,24 @@ describe FastJsonapi::ObjectSerializer, performance: true do
         movies = build_movies(movie_count)
         our_serializer = MovieSerializer.new(movies)
         ams_serializer = ActiveModelSerializers::SerializableResource.new(ams_movies)
+        primalize_serializer = PrimalizeMoviesResponse.new(
+          movies: movies,
+          actors: [],
+          users: [],
+          movie_types: [],
+        )
+
+        pp(
+          ams: ams_serializer.as_json,
+          fast_jsonapi: our_serializer.as_json,
+          primalize: primalize_serializer.call,
+        ) if movie_count == 1
 
         message = "Serialize to JSON string #{movie_count} records"
-        our_json, ams_json = run_json_benchmark(message, movie_count, our_serializer, ams_serializer)
+        our_json, ams_json = run_json_benchmark(message, movie_count, our_serializer, ams_serializer, primalize_serializer)
 
         message = "Serialize to Ruby Hash #{movie_count} records"
-        run_hash_benchmark(message, movie_count, our_serializer, ams_serializer)
+        run_hash_benchmark(message, movie_count, our_serializer, ams_serializer, primalize_serializer)
 
         expect(our_json.length).to eq ams_json.length
         expect { our_serializer.serialized_json }.to perform_faster_than { ams_serializer.to_json }.at_least(speed_factor).times
@@ -94,12 +111,24 @@ describe FastJsonapi::ObjectSerializer, performance: true do
         options[:include] = [:actors, :movie_type]
         our_serializer = MovieSerializer.new(movies, options)
         ams_serializer = ActiveModelSerializers::SerializableResource.new(ams_movies, include: options[:include], meta: options[:meta])
+        primalize_serializer = PrimalizeMoviesResponse.new(
+          movies: movies,
+          actors: movies.flat_map(&:actors).uniq,
+          users: [],
+          movie_types: movies.map(&:movie_type).uniq,
+        )
+
+        pp(
+          ams: ams_serializer.as_json,
+          fast_jsonapi: our_serializer.as_json,
+          primalize: primalize_serializer.call,
+        ) if movie_count == 1
 
         message = "Serialize to JSON string #{movie_count} with includes and meta"
-        our_json, ams_json = run_json_benchmark(message, movie_count, our_serializer, ams_serializer)
+        our_json, ams_json = run_json_benchmark(message, movie_count, our_serializer, ams_serializer, primalize_serializer)
 
         message = "Serialize to Ruby Hash #{movie_count} with includes and meta"
-        run_hash_benchmark(message, movie_count, our_serializer, ams_serializer)
+        run_hash_benchmark(message, movie_count, our_serializer, ams_serializer, primalize_serializer)
 
         expect(our_json.length).to eq ams_json.length
         expect { our_serializer.serialized_json }.to perform_faster_than { ams_serializer.to_json }.at_least(speed_factor).times

--- a/spec/lib/object_serializer_performance_spec.rb
+++ b/spec/lib/object_serializer_performance_spec.rb
@@ -52,18 +52,21 @@ describe FastJsonapi::ObjectSerializer, performance: true do
   def run_hash_benchmark(message, movie_count, our_serializer, ams_serializer, primalize_serializer)
     our_time = Benchmark.measure { our_hash = our_serializer.serializable_hash }.real * 1000
     ams_time = Benchmark.measure { ams_hash = ams_serializer.as_json }.real * 1000
-    primalize_time = Benchmark.measure { primalize_serializer.as_json }.real * 1000
+    primalize_time = Benchmark.measure { primalize_serializer.call }.real * 1000
     print_stats(message, movie_count, ams_time, our_time, primalize_time)
   end
 
   def run_json_benchmark(message, movie_count, our_serializer, ams_serializer, primalize_serializer)
     our_json = nil
     ams_json = nil
+    primalize_json = nil
+
     our_time = Benchmark.measure { our_json = our_serializer.serialized_json }.real * 1000
     ams_time = Benchmark.measure { ams_json = ams_serializer.to_json }.real * 1000
-    primalize_time = Benchmark.measure { primalize_serializer.to_json }.real * 1000
+    primalize_time = Benchmark.measure { primalize_json = primalize_serializer.to_json }.real * 1000
+
     print_stats(message, movie_count, ams_time, our_time, primalize_time)
-    return our_json, ams_json
+    return our_json, ams_json, primalize_json
   end
 
   context 'when comparing with AMS 0.10.x' do
@@ -74,18 +77,7 @@ describe FastJsonapi::ObjectSerializer, performance: true do
         movies = build_movies(movie_count)
         our_serializer = MovieSerializer.new(movies)
         ams_serializer = ActiveModelSerializers::SerializableResource.new(ams_movies)
-        primalize_serializer = PrimalizeMoviesResponse.new(
-          movies: movies,
-          actors: [],
-          users: [],
-          movie_types: [],
-        )
-
-        pp(
-          ams: ams_serializer.as_json,
-          fast_jsonapi: our_serializer.as_json,
-          primalize: primalize_serializer.call,
-        ) if movie_count == 1
+        primalize_serializer = PrimalizeMovieSerializer.new(movies)
 
         message = "Serialize to JSON string #{movie_count} records"
         our_json, ams_json = run_json_benchmark(message, movie_count, our_serializer, ams_serializer, primalize_serializer)
@@ -111,26 +103,16 @@ describe FastJsonapi::ObjectSerializer, performance: true do
         options[:include] = [:actors, :movie_type]
         our_serializer = MovieSerializer.new(movies, options)
         ams_serializer = ActiveModelSerializers::SerializableResource.new(ams_movies, include: options[:include], meta: options[:meta])
-        primalize_serializer = PrimalizeMoviesResponse.new(
-          movies: movies,
-          actors: movies.flat_map(&:actors).uniq,
-          users: [],
-          movie_types: movies.map(&:movie_type).uniq,
-        )
-
-        pp(
-          ams: ams_serializer.as_json,
-          fast_jsonapi: our_serializer.as_json,
-          primalize: primalize_serializer.call,
-        ) if movie_count == 1
+        primalize_serializer = PrimalizeMovieSerializer.new(movies, options)
 
         message = "Serialize to JSON string #{movie_count} with includes and meta"
-        our_json, ams_json = run_json_benchmark(message, movie_count, our_serializer, ams_serializer, primalize_serializer)
+        our_json, ams_json, primalize_json = run_json_benchmark(message, movie_count, our_serializer, ams_serializer, primalize_serializer)
 
         message = "Serialize to Ruby Hash #{movie_count} with includes and meta"
         run_hash_benchmark(message, movie_count, our_serializer, ams_serializer, primalize_serializer)
 
         expect(our_json.length).to eq ams_json.length
+        expect(primalize_json.length).to eq our_json.length
         expect { our_serializer.serialized_json }.to perform_faster_than { ams_serializer.to_json }.at_least(speed_factor).times
         expect { our_serializer.serializable_hash }.to perform_faster_than { ams_serializer.as_json }.at_least(speed_factor).times
       end

--- a/spec/shared/contexts/movie_context.rb
+++ b/spec/shared/contexts/movie_context.rb
@@ -23,6 +23,13 @@ RSpec.shared_context 'movie class' do
         mt
       end
 
+      def owner
+        o = User.new
+        o.id = owner_id
+        o.name = 'Jamie'
+        o
+      end
+
       def cache_key
         "#{id}"
       end
@@ -30,6 +37,10 @@ RSpec.shared_context 'movie class' do
 
     class Actor
       attr_accessor :id, :name, :email
+    end
+
+    class User
+      attr_accessor :id, :name
     end
 
     class MovieType

--- a/spec/shared/contexts/primalize_context.rb
+++ b/spec/shared/contexts/primalize_context.rb
@@ -1,0 +1,53 @@
+require 'primalize'
+
+RSpec.shared_context 'primalize movie class' do
+  before :context do
+
+    class PrimalizeMovieSerializer < Primalize::Single
+      attributes(
+        id: integer,
+        name: string,
+        release_year: optional(integer),
+        actor_ids: array(integer),
+        owner_id: integer,
+        movie_type_id: integer,
+      )
+    end
+
+    class PrimalizeActorSerializer < Primalize::Single
+      attributes(
+        id: integer,
+        name: string,
+        email: string,
+      )
+    end
+
+    class PrimalizeUserSerializer < Primalize::Single
+      attributes(id: integer, name: string)
+    end
+
+    class PrimalizeMovieTypeSerializer < Primalize::Single
+      attributes(id: integer, name: string)
+    end
+
+    class PrimalizeMoviesResponse < Primalize::Many
+      attributes(
+        movies: enumerable(PrimalizeMovieSerializer),
+        actors: enumerable(PrimalizeActorSerializer),
+        users: enumerable(PrimalizeUserSerializer),
+        movie_types: enumerable(PrimalizeMovieTypeSerializer),
+      )
+    end
+  end
+
+  after :context do
+    %w(
+      PrimalizeMovieSerializer
+      PrimalizeActorSerializer
+      PrimalizeUserSerializer
+      PrimalizeMovieSerializer
+    ).each do |klass_name|
+      Object.send(:remove_const, klass_name) if Object.constants.include?(klass_name)
+    end
+  end
+end

--- a/spec/shared/contexts/primalize_context.rb
+++ b/spec/shared/contexts/primalize_context.rb
@@ -1,42 +1,32 @@
-require 'primalize'
+require 'primalize/jsonapi'
 
 RSpec.shared_context 'primalize movie class' do
   before :context do
 
-    class PrimalizeMovieSerializer < Primalize::Single
+    class PrimalizeMovieSerializer < Primalize::JSONAPI[Movie]
       attributes(
-        id: integer,
         name: string,
         release_year: optional(integer),
-        actor_ids: array(integer),
-        owner_id: integer,
-        movie_type_id: integer,
       )
+
+      has_many(:actors) { PrimalizeActorSerializer }
+      has_one(:owner) { PrimalizeUserSerializer }
+      has_one(:movie_type) { PrimalizeMovieTypeSerializer }
     end
 
-    class PrimalizeActorSerializer < Primalize::Single
+    class PrimalizeActorSerializer < Primalize::JSONAPI[Actor]
       attributes(
-        id: integer,
         name: string,
         email: string,
       )
     end
 
-    class PrimalizeUserSerializer < Primalize::Single
-      attributes(id: integer, name: string)
+    class PrimalizeUserSerializer < Primalize::JSONAPI[User]
+      attributes(name: string)
     end
 
-    class PrimalizeMovieTypeSerializer < Primalize::Single
-      attributes(id: integer, name: string)
-    end
-
-    class PrimalizeMoviesResponse < Primalize::Many
-      attributes(
-        movies: enumerable(PrimalizeMovieSerializer),
-        actors: enumerable(PrimalizeActorSerializer),
-        users: enumerable(PrimalizeUserSerializer),
-        movie_types: enumerable(PrimalizeMovieTypeSerializer),
-      )
+    class PrimalizeMovieTypeSerializer < Primalize::JSONAPI[MovieType]
+      attributes(name: string)
     end
   end
 


### PR DESCRIPTION
Primalize has different opinions about structure than the JSON API, so the output isn't the same, but I thought it might be useful to have another performance datapoint.

I just noticed I left some debugging output in there. I'll remove it if you're interested in merging.