### PR TITLE
Refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,8 +26,7 @@ pkg
 #*.tmproj
 #tmtags
 
-# For vim:
-#*.swp
+*.swp
 
 # For redcar:
 #.redcar

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fast JSON API
 
-[![NetflixOSS Lifecycle](https://img.shields.io/osslifecycle/Netflix/osstracker.svg)]()
+[![Build Status](https://travis-ci.org/Netflix/fast_jsonapi.svg?branch=master)](https://travis-ci.org/Netflix/fast_jsonapi)
 
 A lightning fast [JSON:API](http://jsonapi.org/) serializer for Ruby Objects.
 
@@ -178,7 +178,7 @@ serializer | Set custom Serializer for a relationship | ```has_many :actors, ser
 
 ## Contributing
 
-Please follow the steps on [contribution checklist](https://github.com/Netflix/fast_jsonapi/blob/master/CONTRIBUTING.md).
+Please follow the steps on [contribution check](https://github.com/Netflix/fast_jsonapi/blob/master/CONTRIBUTING.md).
 This gem is built using a gem building gem called [juwelier](https://github.com/flajann2/juwelier).
 
 Beyond just editing source code, you’ll be interacting with the gem using rake a lot. To see all the tasks available with a brief description, you can run:

--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -30,47 +30,45 @@ module FastJsonapi
       end
 
       # Set record_type based on the name of the serializer class
-      set_type default_record_type if default_record_type
+      set_type(reflected_record_type) if reflected_record_type
     end
 
     def initialize(resource, options = {})
-      if options.present?
-        @meta_tags = options[:meta]
-        @includes = options[:include].delete_if(&:blank?) if options[:include].present?
-        self.class.has_permitted_includes(@includes) if @includes.present?
-        @known_included_objects = {} # keep track of inc objects that have already been serialized
-      end
-      # @records if enumerables like Array, ActiveRecord::Relation but if Struct just make it a @record
-      if resource.respond_to?(:each) && !resource.respond_to?(:each_pair)
-        @records = resource
-      else
-        @record = resource
-      end
+      process_options(options)
+
+      @resource = resource
     end
 
     def serializable_hash
+      return hash_for_collection if is_collection?(@resource)
+
+      hash_for_one_record
+    end
+
+    def hash_for_one_record
       serializable_hash = { data: nil }
-      serializable_hash[:meta] = @meta_tags if @meta_tags.present?
-      return hash_for_one_record(serializable_hash) if @record
-      return hash_for_multiple_records(serializable_hash) if @records
+      serializable_hash[:meta] = @meta if @meta.present?
+
+      return serializable_hash unless @resource
+
+      serializable_hash[:data] = self.class.record_hash(@resource)
+      serializable_hash[:included] = self.class.get_included_records(@resource, @includes, @known_included_objects) if @includes.present?
       serializable_hash
     end
 
-    def hash_for_one_record(serializable_hash)
-      serializable_hash[:data] = self.class.record_hash(@record)
-      serializable_hash[:included] = self.class.get_included_records(@record, @includes, @known_included_objects) if @includes.present?
-      serializable_hash
-    end
+    def hash_for_collection
+      serializable_hash = {}
 
-    def hash_for_multiple_records(serializable_hash)
       data = []
       included = []
-      @records.each do |record|
+      @resource.each do |record|
         data << self.class.record_hash(record)
         included.concat self.class.get_included_records(record, @includes, @known_included_objects) if @includes.present?
       end
+
       serializable_hash[:data] = data
       serializable_hash[:included] = included if @includes.present?
+      serializable_hash[:meta] = @meta if @meta.present?
       serializable_hash
     end
 
@@ -78,23 +76,55 @@ module FastJsonapi
       self.class.to_json(serializable_hash)
     end
 
+    private
+
+    def process_options(options)
+      return if options.blank?
+
+      @known_included_objects = {}
+      @meta = options[:meta]
+
+      if options[:include].present?
+        @includes = options[:include].delete_if(&:blank?)
+        validate_includes!(@includes)
+      end
+    end
+
+    def validate_includes!(includes)
+      return if includes.blank?
+
+      existing_relationships = self.class.relationships_to_serialize.keys.to_set
+
+      unless existing_relationships.superset?(includes.to_set)
+        raise ArgumentError, "One of keys from #{includes} is not specified as a relationship on the serializer"
+      end
+    end
+
+    def is_collection?(resource)
+      resource.respond_to?(:each) && !resource.respond_to?(:each_pair)
+    end
+
     class_methods do
       def use_hyphen
         @hyphenated = true
       end
 
-      def set_type(type_name)
-        self.record_type = type_name
-        if @hyphenated
-          self.record_type = type_name.to_s.dasherize.to_sym
-        end
+      def set_type(type)
+        return unless type
+
+        type = type.to_s.underscore
+        type = type.dasherize if @hyphenated
+
+        self.record_type = type.to_sym
       end
 
-      def default_record_type
-        if self.name.end_with?('Serializer')
-          class_name = self.name.demodulize
-          range_end = class_name.rindex('Serializer')
-          class_name[0...range_end].underscore.to_sym
+      def reflected_record_type
+        return @reflected_record_type if defined?(@reflected_record_type)
+
+        @reflected_record_type ||= begin
+          if self.name.end_with?('Serializer')
+            self.name.split('::').last.chomp('Serializer').underscore.to_sym
+          end
         end
       end
 

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -94,17 +94,6 @@ module FastJsonapi
         end
         included_records
       end
-
-      def has_permitted_includes(requested_includes)
-        # requested includes should be within relationships defined on serializer
-        allowed_includes = @relationships_to_serialize.keys
-        intersection = allowed_includes & requested_includes
-        if intersection.sort == requested_includes.sort
-          true
-        else
-          raise ArgumentError, "One of keys from #{requested_includes} is not specified as a relationship on the serializer"
-        end
-      end
     end
   end
 end

--- a/spec/lib/object_serializer_performance_spec.rb
+++ b/spec/lib/object_serializer_performance_spec.rb
@@ -34,12 +34,28 @@ describe FastJsonapi::ObjectSerializer, performance: true do
     end
   end
 
-  def print_stats(count, ams_time, our_time)
+  def print_stats(message, count, ams_time, our_time)
     format = '%-15s %-10s %s'
     puts ''
+    puts message
     puts format(format, 'Serializer', 'Records', 'Time')
     puts format(format, 'AMS serializer', count, ams_time.round(2).to_s + ' ms')
     puts format(format, 'Fast serializer', count, our_time.round(2).to_s + ' ms')
+  end
+
+  def run_hash_benchmark(message, movie_count, our_serializer, ams_serializer)
+    our_time = Benchmark.measure { our_hash = our_serializer.serializable_hash }.real * 1000
+    ams_time = Benchmark.measure { ams_hash = ams_serializer.as_json }.real * 1000
+    print_stats(message, movie_count, ams_time, our_time)
+  end
+
+  def run_json_benchmark(message, movie_count, our_serializer, ams_serializer)
+    our_json = nil
+    ams_json = nil
+    our_time = Benchmark.measure { our_json = our_serializer.serialized_json }.real * 1000
+    ams_time = Benchmark.measure { ams_json = ams_serializer.to_json }.real * 1000
+    print_stats(message, movie_count, ams_time, our_time)
+    return our_json, ams_json
   end
 
   context 'when comparing with AMS 0.10.x' do
@@ -48,15 +64,18 @@ describe FastJsonapi::ObjectSerializer, performance: true do
       it "should serialize #{movie_count} records atleast #{speed_factor} times faster than AMS" do
         ams_movies = build_ams_movies(movie_count)
         movies = build_movies(movie_count)
-        our_json = nil
-        ams_json = nil
         our_serializer = MovieSerializer.new(movies)
         ams_serializer = ActiveModelSerializers::SerializableResource.new(ams_movies)
-        our_time = Benchmark.measure { our_json = our_serializer.serialized_json }.real * 1000
-        ams_time = Benchmark.measure { ams_json = ams_serializer.to_json }.real * 1000
-        print_stats(movie_count, ams_time, our_time)
+
+        message = "Serialize to JSON string #{movie_count} records"
+        our_json, ams_json = run_json_benchmark(message, movie_count, our_serializer, ams_serializer)
+
+        message = "Serialize to Ruby Hash #{movie_count} records"
+        run_hash_benchmark(message, movie_count, our_serializer, ams_serializer)
+
         expect(our_json.length).to eq ams_json.length
         expect { our_serializer.serialized_json }.to perform_faster_than { ams_serializer.to_json }.at_least(speed_factor).times
+        expect { our_serializer.serializable_hash }.to perform_faster_than { ams_serializer.as_json }.at_least(speed_factor).times
       end
     end
   end
@@ -67,20 +86,21 @@ describe FastJsonapi::ObjectSerializer, performance: true do
       it "should serialize #{movie_count} records atleast #{speed_factor} times faster than AMS" do
         ams_movies = build_ams_movies(movie_count)
         movies = build_movies(movie_count)
-        our_json = nil
-        ams_json = nil
-
         options = {}
         options[:meta] = { total: movie_count }
         options[:include] = [:actors, :movie_type]
-
         our_serializer = MovieSerializer.new(movies, options)
         ams_serializer = ActiveModelSerializers::SerializableResource.new(ams_movies, include: options[:include], meta: options[:meta])
-        our_time = Benchmark.measure { our_json = our_serializer.serialized_json }.real * 1000
-        ams_time = Benchmark.measure { ams_json = ams_serializer.to_json }.real * 1000
-        print_stats(movie_count, ams_time, our_time)
+
+        message = "Serialize to JSON string #{movie_count} with includes and meta"
+        our_json, ams_json = run_json_benchmark(message, movie_count, our_serializer, ams_serializer)
+
+        message = "Serialize to Ruby Hash #{movie_count} with includes and meta"
+        run_hash_benchmark(message, movie_count, our_serializer, ams_serializer)
+
         expect(our_json.length).to eq ams_json.length
         expect { our_serializer.serialized_json }.to perform_faster_than { ams_serializer.to_json }.at_least(speed_factor).times
+        expect { our_serializer.serializable_hash }.to perform_faster_than { ams_serializer.as_json }.at_least(speed_factor).times
       end
     end
   end

--- a/spec/lib/object_serializer_performance_spec.rb
+++ b/spec/lib/object_serializer_performance_spec.rb
@@ -4,6 +4,9 @@ describe FastJsonapi::ObjectSerializer, performance: true do
   include_context 'movie class'
   include_context 'ams movie class'
 
+  before(:all) { GC.disable }
+  after(:all) { GC.enable }
+
   context 'when testing performance of serialization' do
     it 'should create a hash of 1000 records in less than 50 ms' do
       movies = 1000.times.map { |_i| movie }

--- a/spec/shared/contexts/movie_context.rb
+++ b/spec/shared/contexts/movie_context.rb
@@ -123,9 +123,7 @@ RSpec.shared_context 'movie class' do
       :id, :name, :release_year, :actor_ids, :actors, :owner_id, :owner, :movie_type_id
     )
 
-    ActorStruct = Struct.new(
-      :id, :name, :email
-    )
+    ActorStruct = Struct.new(:id, :name, :email)
   end
 
   after(:context) do
@@ -151,10 +149,7 @@ RSpec.shared_context 'movie class' do
     actors = []
 
     3.times.each do |id|
-      a = ActorStruct.new
-      a[:id] = id
-      a[:name] = id.to_s
-      actors << a
+      actors << ActorStruct.new(id, id.to_s, id.to_s)
     end
 
     m = MovieStruct.new

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require 'rspec-benchmark'
 require 'multi_json'
 require 'byebug'
 require 'active_model_serializers'
+require 'oj'
 
 Dir[File.dirname(__FILE__) + '/shared/contexts/*.rb'].each {|file| require file }
 
@@ -13,6 +14,7 @@ RSpec.configure do |config|
   end
 end
 
+Oj.optimize_rails
 ActiveModel::Serializer.config.adapter = :json_api
 ActiveModel::Serializer.config.key_transform = :underscore
 ActiveModelSerializers.logger = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new('/dev/null'))


### PR DESCRIPTION
Hi, I've refactored a little bit of `object_serializer` module.

I've renamed `default_record_type` to `reflected_record_type` because we use reflection to guess that type. Also, I've added memoization to that method, so we don't calculate type every time we call `reflected_record_type`.

I've extracted logic of initialization into a separate private method.

Besides that, I've combined `@record` and `@records` into one variable `@resource` and added `is_collection?` helper that should help to figure out if it's a collection.

There are couple smaller changes.
I used existing performance specs and `benchmark-ips` gem to verify that performance didn't change after refactoring.

Thanks for a great gem!