### PR TITLE
Use Object#public_send to respect attributes visibility

### DIFF
--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -28,7 +28,7 @@ module FastJsonapi
 
       def attributes_hash(record)
         attributes_to_serialize.each_with_object({}) do |(key, method_name), attr_hash|
-          attr_hash[key] = record.send(method_name)
+          attr_hash[key] = record.public_send(method_name)
         end
       end
 
@@ -41,7 +41,7 @@ module FastJsonapi
           record_type = relationship[:record_type]
           empty_case = relationship[:relationship_type] == :has_many ? [] : nil
           hash[name] = {
-            data: ids_hash(record.send(id_method_name), record_type) || empty_case
+            data: ids_hash(record.public_send(id_method_name), record_type) || empty_case
           }
         end
       end


### PR DESCRIPTION
While working on other feature I found that fast_jsonapi serializers are able to call private methods in the record object and I think this isn't the intended behavior.

This replaces `Object#send` with`Object#public_send` to avoid the calling of private methods in serializers.