### PR TITLE
Add support for custom attribute methods.

### DIFF
--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -50,8 +50,8 @@ module FastJsonapi
 
       return serializable_hash unless @resource
 
-      serializable_hash[:data] = self.class.record_hash(@resource)
-      serializable_hash[:included] = self.class.get_included_records(@resource, @includes, @known_included_objects) if @includes.present?
+      serializable_hash[:data] = self.record_hash
+      serializable_hash[:included] = self.get_included_records(@includes, @known_included_objects) if @includes.present?
       serializable_hash
     end
 
@@ -61,8 +61,9 @@ module FastJsonapi
       data = []
       included = []
       @resource.each do |record|
-        data << self.class.record_hash(record)
-        included.concat self.class.get_included_records(record, @includes, @known_included_objects) if @includes.present?
+        serializer = self.class.new(record)
+        data << serializer.record_hash
+        included.concat serializer.get_included_records(@includes, @known_included_objects) if @includes.present?
       end
 
       serializable_hash[:data] = data
@@ -72,7 +73,7 @@ module FastJsonapi
     end
 
     def serialized_json
-      self.class.to_json(serializable_hash)
+      self.to_json(serializable_hash)
     end
 
     private

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -16,76 +16,78 @@ module FastJsonapi
       end
     end
 
-    class_methods do
-      def id_hash(id, record_type)
-        return { id: id.to_s, type: record_type } if id.present?
-      end
+    def record
+      @resource
+    end
 
-      def ids_hash(ids, record_type)
-        return ids.map { |id| id_hash(id, record_type) } if ids.respond_to? :map
-        id_hash(ids, record_type) # ids variable is just a single id here
-      end
+    def id_hash(id, record_type)
+      return { id: id.to_s, type: record_type } if id.present?
+    end
 
-      def attributes_hash(record)
-        attributes_to_serialize.each_with_object({}) do |(key, method_name), attr_hash|
-          attr_hash[key] = record.public_send(method_name)
+    def ids_hash(ids, record_type)
+      return ids.map { |id| id_hash(id, record_type) } if ids.respond_to? :map
+      id_hash(ids, record_type) # ids variable is just a single id here
+    end
+
+    def attributes_hash
+      self.class.attributes_to_serialize.each_with_object({}) do |(key, method_name), attr_hash|
+        attr_hash[key] = respond_to?(method_name) ? public_send(method_name) : record.public_send(method_name)
+      end
+    end
+
+    def relationships_hash(relationships = nil)
+      relationships = self.class.relationships_to_serialize if relationships.nil?
+
+      relationships.each_with_object({}) do |(_k, relationship), hash|
+        name = relationship[:key]
+        id_method_name = relationship[:id_method_name]
+        record_type = relationship[:record_type]
+        empty_case = relationship[:relationship_type] == :has_many ? [] : nil
+        hash[name] = {
+          data: ids_hash(record.public_send(id_method_name), record_type) || empty_case
+        }
+      end
+    end
+
+    def record_hash
+      if self.class.cached
+        record_hash = Rails.cache.fetch(record.cache_key, expires_in: self.class.cache_length) do
+          temp_hash = id_hash(record.id, self.class.record_type) || { id: nil, type: self.class.record_type }
+          temp_hash[:attributes] = attributes_hash if self.class.attributes_to_serialize.present?
+          temp_hash[:relationships] = {}
+          temp_hash[:relationships] = relationships_hash(self.class.cachable_relationships_to_serialize) if self.class.cachable_relationships_to_serialize.present?
+          temp_hash
         end
+        record_hash[:relationships] = record_hash[:relationships].merge(relationships_hash(self.class.uncachable_relationships_to_serialize)) if self.class.uncachable_relationships_to_serialize.present?
+        record_hash
+      else
+        record_hash = id_hash(record.id, self.class.record_type) || { id: nil, type: self.class.record_type }
+        record_hash[:attributes] = attributes_hash if self.class.attributes_to_serialize.present?
+        record_hash[:relationships] = relationships_hash if self.class.relationships_to_serialize.present?
+        record_hash
       end
+    end
 
-      def relationships_hash(record, relationships = nil)
-        relationships = relationships_to_serialize if relationships.nil?
+    def to_json(payload)
+      MultiJson.dump(payload) if payload.present?
+    end
 
-        relationships.each_with_object({}) do |(_k, relationship), hash|
-          name = relationship[:key]
-          id_method_name = relationship[:id_method_name]
-          record_type = relationship[:record_type]
-          empty_case = relationship[:relationship_type] == :has_many ? [] : nil
-          hash[name] = {
-            data: ids_hash(record.public_send(id_method_name), record_type) || empty_case
-          }
-        end
-      end
+    # includes handler
 
-      def record_hash(record)
-        if cached
-          record_hash = Rails.cache.fetch(record.cache_key, expires_in: cache_length) do
-            temp_hash = id_hash(record.id, record_type) || { id: nil, type: record_type }
-            temp_hash[:attributes] = attributes_hash(record) if attributes_to_serialize.present?
-            temp_hash[:relationships] = {}
-            temp_hash[:relationships] = relationships_hash(record, cachable_relationships_to_serialize) if cachable_relationships_to_serialize.present?
-            temp_hash
-          end
-          record_hash[:relationships] = record_hash[:relationships].merge(relationships_hash(record, uncachable_relationships_to_serialize)) if uncachable_relationships_to_serialize.present?
-          record_hash
-        else
-          record_hash = id_hash(record.id, record_type) || { id: nil, type: record_type }
-          record_hash[:attributes] = attributes_hash(record) if attributes_to_serialize.present?
-          record_hash[:relationships] = relationships_hash(record) if relationships_to_serialize.present?
-          record_hash
-        end
-      end
-
-      def to_json(payload)
-        MultiJson.dump(payload) if payload.present?
-      end
-
-      # includes handler
-
-      def get_included_records(record, includes_list, known_included_objects)
-        includes_list.each_with_object([]) do |item, included_records|
-          object_method_name = @relationships_to_serialize[item][:object_method_name]
-          record_type = @relationships_to_serialize[item][:record_type]
-          serializer = @relationships_to_serialize[item][:serializer].to_s.constantize
-          relationship_type = @relationships_to_serialize[item][:relationship_type]
-          included_objects = record.send(object_method_name)
-          next if included_objects.blank?
-          included_objects = [included_objects] unless relationship_type == :has_many
-          included_objects.each do |inc_obj|
-            code = "#{record_type}_#{inc_obj.id}"
-            next if known_included_objects.key?(code)
-            known_included_objects[code] = inc_obj
-            included_records << serializer.record_hash(inc_obj)
-          end
+    def get_included_records(includes_list, known_included_objects)
+      includes_list.each_with_object([]) do |item, included_records|
+        object_method_name = self.class.relationships_to_serialize[item][:object_method_name]
+        record_type = self.class.relationships_to_serialize[item][:record_type]
+        serializer = self.class.relationships_to_serialize[item][:serializer].to_s.constantize
+        relationship_type = self.class.relationships_to_serialize[item][:relationship_type]
+        included_objects = record.send(object_method_name)
+        next if included_objects.blank?
+        included_objects = [included_objects] unless relationship_type == :has_many
+        included_objects.each do |inc_obj|
+          code = "#{record_type}_#{inc_obj.id}"
+          next if known_included_objects.key?(code)
+          known_included_objects[code] = inc_obj
+          included_records << serializer.new(inc_obj).record_hash
         end
       end
     end

--- a/spec/lib/object_serializer_with_custom_method_spec.rb
+++ b/spec/lib/object_serializer_with_custom_method_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe FastJsonapi::ObjectSerializer do
+  include_context 'movie class'
+
+  context 'when including custom methods defined in serializer in attributes' do
+    it 'returns correct hash when serializable_hash is called' do
+      serializable_hash = MovieSerializerWithCustomMethod.new([movie, movie]).serializable_hash
+      expect(serializable_hash[:data].length).to eq 2
+      expect(serializable_hash[:data][0][:attributes].length).to eq 3
+      expect(serializable_hash[:data][0][:attributes]).to have_key(:title_with_year)
+
+      serializable_hash = MovieSerializerWithCustomMethod.new(movie_struct).serializable_hash
+      expect(serializable_hash[:data][:attributes].length).to eq 3
+      expect(serializable_hash[:data][:attributes]).to have_key(:title_with_year)
+    end
+  end
+end

--- a/spec/lib/serialization_core_spec.rb
+++ b/spec/lib/serialization_core_spec.rb
@@ -7,29 +7,29 @@ describe FastJsonapi::ObjectSerializer do
     it 'returns correct hash when id_hash is called' do
       inputs = [{id: 23, record_type: :movie}, {id: 'x', record_type: 'person'}]
       inputs.each do |hash|
-        result_hash = MovieSerializer.send(:id_hash, hash[:id], hash[:record_type])
+        result_hash = MovieSerializer.new(movie).send(:id_hash, hash[:id], hash[:record_type])
         expect(result_hash[:id]).to eq hash[:id].to_s
         expect(result_hash[:type]).to eq hash[:record_type]
       end
 
-      result_hash = MovieSerializer.send(:id_hash, nil, 'movie')
+      result_hash = MovieSerializer.new(movie).send(:id_hash, nil, 'movie')
       expect(result_hash).to be nil
     end
 
     it 'returns correct hash when ids_hash is called' do
       inputs = [{ids: %w(1 2 3), record_type: :movie}, {ids: %w(x y z), record_type: 'person'}]
       inputs.each do |hash|
-        results = MovieSerializer.send(:ids_hash, hash[:ids], hash[:record_type])
+        results = MovieSerializer.new(movie).send(:ids_hash, hash[:ids], hash[:record_type])
         expect(results.map{|h| h[:id]}).to eq hash[:ids]
         expect(results[0][:type]).to eq hash[:record_type]
       end
 
-      result = MovieSerializer.send(:ids_hash, [], 'movie')
+      result = MovieSerializer.new(movie).send(:ids_hash, [], 'movie')
       expect(result).to be_empty
     end
 
     it 'returns correct hash when attributes_hash is called' do
-      attributes_hash = MovieSerializer.send(:attributes_hash, movie)
+      attributes_hash = MovieSerializer.new(movie).send(:attributes_hash)
       attribute_names = attributes_hash.keys.sort
       expect(attribute_names).to eq MovieSerializer.attributes_to_serialize.keys.sort
       MovieSerializer.attributes_to_serialize.each do |key, method_name|
@@ -41,13 +41,13 @@ describe FastJsonapi::ObjectSerializer do
     it 'returns the correct empty result when relationships_hash is called' do
       movie.actor_ids = []
       movie.owner_id = nil
-      relationships_hash = MovieSerializer.send(:relationships_hash, movie)
+      relationships_hash = MovieSerializer.new(movie).send(:relationships_hash)
       expect(relationships_hash[:actors][:data]).to eq([])
       expect(relationships_hash[:owner][:data]).to eq(nil)
     end
 
     it 'returns correct keys when relationships_hash is called' do
-      relationships_hash = MovieSerializer.send(:relationships_hash, movie)
+      relationships_hash = MovieSerializer.new(movie).send(:relationships_hash)
       relationship_names = relationships_hash.keys.sort
       relationships_hashes = MovieSerializer.relationships_to_serialize.values
       expected_names = relationships_hashes.map{|relationship| relationship[:key]}.sort
@@ -55,7 +55,7 @@ describe FastJsonapi::ObjectSerializer do
     end
 
     it 'returns correct values when relationships_hash is called' do
-      relationships_hash = MovieSerializer.relationships_hash(movie)
+      relationships_hash = MovieSerializer.new(movie).relationships_hash
       actors_hash = movie.actor_ids.map { |id|  {id: id.to_s, type: :actor} }
       owner_hash = {id: movie.owner_id.to_s, type: :user}
       expect(relationships_hash[:actors][:data]).to match_array actors_hash
@@ -63,7 +63,7 @@ describe FastJsonapi::ObjectSerializer do
     end
 
     it 'returns correct hash when record_hash is called' do
-      record_hash = MovieSerializer.send(:record_hash, movie)
+      record_hash = MovieSerializer.new(movie).send(:record_hash)
       expect(record_hash[:id]).to eq movie.id.to_s
       expect(record_hash[:type]).to eq MovieSerializer.record_type
       expect(record_hash).to have_key(:attributes) if MovieSerializer.attributes_to_serialize.present?
@@ -75,7 +75,7 @@ describe FastJsonapi::ObjectSerializer do
       known_included_objects = {}
       included_records = []
       [movie, movie].each do |record|
-        included_records.concat MovieSerializer.send(:get_included_records, record, includes_list, known_included_objects)
+        included_records.concat MovieSerializer.new(record).send(:get_included_records, includes_list, known_included_objects)
       end
       expect(included_records.size).to eq 3
     end

--- a/spec/shared/contexts/ams_context.rb
+++ b/spec/shared/contexts/ams_context.rb
@@ -37,6 +37,14 @@ RSpec.shared_context 'ams movie class' do
       type 'movie_type'
       attributes :name
     end
+    class AMSMovieSerializerWithCustomMethod < ActiveModel::Serializer
+      type 'movie'
+      attributes :name, :release_year, :title_with_year
+
+      def title_with_year
+        "#{object.name} (#{object.release_year})"
+      end
+    end
   end
 
   after(:context) do

--- a/spec/shared/contexts/movie_context.rb
+++ b/spec/shared/contexts/movie_context.rb
@@ -79,6 +79,16 @@ RSpec.shared_context 'movie class' do
       set_type :movie_type
       attributes :name
     end
+
+    class MovieSerializerWithCustomMethod
+      include FastJsonapi::ObjectSerializer
+      set_type :movie
+      attributes :name, :release_year, :title_with_year
+
+      def title_with_year
+        "#{record.name} (#{record.release_year})"
+      end
+    end
   end
 
 
@@ -134,6 +144,7 @@ RSpec.shared_context 'movie class' do
       ActorSerializer
       MovieType
       MovieTypeSerializer
+      MovieSerializerWithCustomMethod
       AppName::V1::MovieSerializer
       MovieStruct
       ActorStruct


### PR DESCRIPTION
This adds support for custom attribute methods as suggested in #5.

```ruby
class MovieSerializer
  include FastJsonapi::ObjectSerializer
  attributes :name, :release_year, :title_with_year

  def title_with_year
    "#{record.name} (#{record.release_year})"
  end
end
```

This required substantial changes in the API, moving the SerializationCore methods from class to instance level making it more similar to AMS API.

