### PR TITLE
Better usage of AMS::Model

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  active_model_serializers (~> 0.10.4)
+  active_model_serializers (~> 0.10.7)
   activerecord (~> 5.0)
   bundler (~> 1.0)
   byebug

--- a/fast_jsonapi.gemspec
+++ b/fast_jsonapi.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |gem|
   gem.version = "1.0.17"
 
   gem.required_rubygems_version = Gem::Requirement.new(">= 0") if gem.respond_to? :required_rubygems_version=
-  gem.metadata = { "allowed_push_host" => "https://rubygemgem.org" } if gem.respond_to? :metadata=
+  gem.metadata = { "allowed_push_host" => "https://rubygems.org" } if gem.respond_to? :metadata=
   gem.require_paths = ["lib"]
   gem.authors = ["Shishir Kakaraddi", "Srinivas Raghunathan", "Adam Gross"]
   gem.date = "2018-02-01"

--- a/fast_jsonapi.gemspec
+++ b/fast_jsonapi.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency(%q<rspec-benchmark>, ["~> 0.3.0"])
   gem.add_development_dependency(%q<bundler>, ["~> 1.0"])
   gem.add_development_dependency(%q<byebug>, [">= 0"])
-  gem.add_development_dependency(%q<active_model_serializers>, ["~> 0.10.4"])
+  gem.add_development_dependency(%q<active_model_serializers>, ["~> 0.10.7"])
   gem.add_development_dependency(%q<sqlite3>, ["~> 1.3"])
 end

--- a/spec/shared/contexts/ams_context.rb
+++ b/spec/shared/contexts/ams_context.rb
@@ -1,34 +1,28 @@
 RSpec.shared_context 'ams movie class' do
   before(:context) do
     # models
-    class AMSMovie < ActiveModelSerializers::Model
-      attr_accessor :id, :name, :release_year, :actors, :owner, :movie_type
+    class AMSModel < ActiveModelSerializers::Model
+      derive_attributes_from_names_and_fix_accessors
+    end
+    class AMSMovie < AMSModel
+      attributes :id, :name, :release_year, :actors, :owner, :movie_type
     end
 
-    class AMSActor < ActiveModelSerializers::Model
-      attr_accessor :id, :name, :email
+    class AMSActor < AMSModel
+      attributes :id, :name, :email
     end
 
-    class AMSUser < ActiveModelSerializers::Model
-      attr_accessor :id, :name
+    class AMSUser < AMSModel
+      attributes :id, :name
     end
-    class AMSMovieType < ActiveModelSerializers::Model
-      attr_accessor :id, :name
+    class AMSMovieType < AMSModel
+      attributes :id, :name
     end
     # serializers
-    class AMSMovieSerializer < ActiveModel::Serializer
-      type 'movie'
-      attributes :name, :release_year
-      has_many :actors
-      has_one :owner
-      belongs_to :movie_type
-    end
-
     class AMSActorSerializer < ActiveModel::Serializer
       type 'actor'
       attributes :name, :email
     end
-
     class AMSUserSerializer < ActiveModel::Serializer
       type 'user'
       attributes :name
@@ -36,6 +30,13 @@ RSpec.shared_context 'ams movie class' do
     class AMSMovieTypeSerializer < ActiveModel::Serializer
       type 'movie_type'
       attributes :name
+    end
+    class AMSMovieSerializer < ActiveModel::Serializer
+      type 'movie'
+      attributes :name, :release_year
+      has_many :actors
+      has_one :owner
+      belongs_to :movie_type
     end
   end
 


### PR DESCRIPTION
Nothing particularly intereting, just, if we're using AMS::Model,
might as well use it as designed.

This also seems to break two of the benchmarks on my machine, making AMS
not quite only 22-24x slower.

I'm not sure whether the benchmark is intended more for regression testing than for a goal.
I could also add benchmarks for the other **two** major AMS releases (:facepalm:).

Note: I am an AMS maintainer, though it isn't much being developed these days.