### PR TITLE
RFC: Let people choose their JSON serializer; JSON:API is not circular

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     fast_jsonapi (1.0.17)
       activesupport (>= 4.2)
-      multi_json (~> 1.12)
 
 GEM
   remote: https://rubygems.org/
@@ -61,7 +60,6 @@ GEM
       nokogiri (>= 1.5.9)
     mini_portile2 (2.3.0)
     minitest (5.10.3)
-    multi_json (1.13.1)
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
     oj (3.4.0)

--- a/fast_jsonapi.gemspec
+++ b/fast_jsonapi.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |gem|
   gem.summary = "fast JSON API(jsonapi.org) serializer"
 
   gem.add_runtime_dependency(%q<activesupport>, [">= 4.2"])
-  gem.add_runtime_dependency(%q<multi_json>, ["~> 1.12"])
   gem.add_development_dependency(%q<activerecord>, [">= 4.2"])
   gem.add_development_dependency(%q<skylight>, ["~> 1.3"])
   gem.add_development_dependency(%q<rspec>, ["~> 3.5.0"])

--- a/lib/fast_jsonapi/multi_to_json.rb
+++ b/lib/fast_jsonapi/multi_to_json.rb
@@ -1,0 +1,90 @@
+# Usage:
+#   class Movie
+#     def to_json(payload)
+#       FastJsonapi::MultiToJson.to_json(payload)
+#     end
+#   end
+module FastJsonapi
+  module MultiToJson
+    # Result object pattern is from https://johnnunemaker.com/resilience-in-ruby/
+    # e.g. https://github.com/github/github-ds/blob/fbda5389711edfb4c10b6c6bad19311dfcb1bac1/lib/github/result.rb
+    class Result
+      def initialize(*rescued_exceptions)
+        rescued_exceptions = [StandardError] if rescued_exceptions.empty?
+        @value = yield
+        @error = nil
+      rescue *rescued_exceptions => e
+        @error = e
+      end
+
+      def ok?
+        @error.nil?
+      end
+
+      def value!
+        if ok?
+          @value
+        else
+          raise @error
+        end
+      end
+
+      def rescue
+        return self if ok?
+        Result.new { yield(@error) }
+      end
+    end
+
+    def self.logger(device=nil)
+      return @logger = Logger.new(device) if device
+      @logger ||= Logger.new(IO::NULL)
+    end
+
+    # Encoder-compatible with default MultiJSON adapters and defaults
+    def self.to_json_method
+      encode_method = String.new(%(def _fast_to_json(object)\n ))
+      encode_method << Result.new(LoadError) {
+        require 'oj'
+        %(::Oj.dump(object, mode: :compat, time_format: :ruby, use_to_json: true))
+      }.rescue {
+        require 'yajl'
+        %(::Yajl::Encoder.encode(object))
+      }.rescue {
+        require 'jrjackson' unless defined?(::JrJackson)
+        %(::JrJackson::Json.dump(object))
+      }.rescue {
+        require 'json'
+        %(JSON.fast_generate(object, create_additions: false, quirks_mode: true))
+      }.rescue {
+        require 'gson'
+        %(::Gson::Encoder.new({}).encode(object))
+      }.rescue {
+        require 'active_support/json/encoding'
+        %(::ActiveSupport::JSON.encode(object))
+      }.rescue {
+        warn "No JSON encoder found. Falling back to `object.to_json`"
+        %(object.to_json)
+      }.value!
+      encode_method << "\nend"
+    end
+
+    def self.to_json(object)
+      _fast_to_json(object)
+    rescue NameError
+      define_to_json(FastJsonapi::MultiToJson)
+      _fast_to_json(object)
+    end
+
+    def self.define_to_json(receiver)
+      cl = caller_locations[0]
+      method_body = to_json_method
+      logger.debug { "Defining #{receiver}._fast_to_json as #{method_body.inspect}" }
+      receiver.instance_eval method_body, cl.absolute_path, cl.lineno
+    end
+
+    def self.reset_to_json!
+      undef :_fast_to_json if method_defined?(:_fast_to_json)
+      logger.debug { "Undefining #{receiver}._fast_to_json" }
+    end
+  end
+end

--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -1,7 +1,6 @@
 require 'active_support/core_ext/object'
 require 'active_support/concern'
 require 'active_support/inflector'
-require 'multi_json'
 require 'fast_jsonapi/serialization_core'
 
 begin

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -65,8 +65,9 @@ module FastJsonapi
         end
       end
 
+      # Override #to_json for alternative implementation
       def to_json(payload)
-        MultiJson.dump(payload) if payload.present?
+        JSON.fast_generate(payload) if payload.present?
       end
 
       # includes handler

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -1,4 +1,5 @@
 require 'active_support/concern'
+require 'fast_jsonapi/multi_to_json'
 
 module FastJsonapi
   module SerializationCore
@@ -67,7 +68,7 @@ module FastJsonapi
 
       # Override #to_json for alternative implementation
       def to_json(payload)
-        JSON.fast_generate(payload) if payload.present?
+        FastJsonapi::MultiToJson.to_json(payload) if payload.present?
       end
 
       # includes handler

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,5 @@
 require 'fast_jsonapi'
 require 'rspec-benchmark'
-require 'multi_json'
 require 'byebug'
 require 'active_model_serializers'
 require 'oj'


### PR DESCRIPTION
For discussion:

- MultiJSON has historically had performance issues, and, in my opinion, is an unnecessary runtime dependency.
  It's just as easy to tell people to write their own `to_json` method if they'd
  like to use something other than the standard library.
- `JSON.fast_generate` is like `JSON.dump` but doesn't check for circle in Ruby objects.
  Since we're always serializing a flattened Hash, that shouldn't be an issue.
  It also isn't overriden by gems like ActiveSupport or oj_mimic_json like `to_json` is,
  so there's less uncertainty about what is actually doing the serialization.