### PR TITLE
Sparse fieldsets support, addresses #57

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,21 @@ options[:include] = [:actors]
 MovieSerializer.new([movie, movie], options).serialized_json
 ```
 
+### Sparse fieldsets
+
+Support for explicit fieldset declaration through ` options[:fields] `. Also works for included records.
+
+```ruby
+options = {}
+options[:meta] = { total: 2 }
+options[:include] = [:actors]
+options[:fields] = {
+  movie: ['name'], # will only include name attribute into attributes hash
+  actor: ['email'] # ...only email for included actors
+}
+MovieSerializer.new([movie, movie], options).serialized_json
+```
+
 ### Collection Serialization
 
 ```ruby

--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -91,7 +91,11 @@ module FastJsonapi
       end
 
       if options[:include].present?
+        fields = options.fetch(:fields, {})
+                        .fetch(self.class.record_type, [])
+                        .map(&:to_sym)
         @includes = options[:include].delete_if(&:blank?)
+        @includes -= fields
         validate_includes!(@includes)
       end
     end

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -26,9 +26,17 @@ module FastJsonapi
         id_hash(ids, record_type) # ids variable is just a single id here
       end
 
-      def attributes_hash(record)
-        attributes_to_serialize.each_with_object({}) do |(key, method_name), attr_hash|
-          attr_hash[key] = record.public_send(method_name)
+      def attributes_hash(record, fields = nil)
+        if fields.is_a? Array
+          fields.each_with_object({}) do |key, attr_hash|
+            if method_name = attributes_to_serialize[key]
+              attr_hash[key] = record.public_send(method_name)
+            end
+          end
+        else
+          attributes_to_serialize.each_with_object({}) do |(key, method_name), attr_hash|
+            attr_hash[key] = record.public_send(method_name)
+          end
         end
       end
 
@@ -46,11 +54,11 @@ module FastJsonapi
         end
       end
 
-      def record_hash(record)
+      def record_hash(record, fields = nil)
         if cached
           record_hash = Rails.cache.fetch(record.cache_key, expires_in: cache_length) do
             temp_hash = id_hash(record.id, record_type) || { id: nil, type: record_type }
-            temp_hash[:attributes] = attributes_hash(record) if attributes_to_serialize.present?
+            temp_hash[:attributes] = attributes_hash(record, fields) if attributes_to_serialize.present?
             temp_hash[:relationships] = {}
             temp_hash[:relationships] = relationships_hash(record, cachable_relationships_to_serialize) if cachable_relationships_to_serialize.present?
             temp_hash
@@ -59,7 +67,7 @@ module FastJsonapi
           record_hash
         else
           record_hash = id_hash(record.id, record_type) || { id: nil, type: record_type }
-          record_hash[:attributes] = attributes_hash(record) if attributes_to_serialize.present?
+          record_hash[:attributes] = attributes_hash(record, fields) if attributes_to_serialize.present?
           record_hash[:relationships] = relationships_hash(record) if relationships_to_serialize.present?
           record_hash
         end
@@ -71,7 +79,7 @@ module FastJsonapi
 
       # includes handler
 
-      def get_included_records(record, includes_list, known_included_objects)
+      def get_included_records(record, includes_list, fields, known_included_objects)
         includes_list.each_with_object([]) do |item, included_records|
           object_method_name = @relationships_to_serialize[item][:object_method_name]
           record_type = @relationships_to_serialize[item][:record_type]
@@ -80,11 +88,12 @@ module FastJsonapi
           included_objects = record.send(object_method_name)
           next if included_objects.blank?
           included_objects = [included_objects] unless relationship_type == :has_many
+          included_fields = fields[record_type]
           included_objects.each do |inc_obj|
             code = "#{record_type}_#{inc_obj.id}"
             next if known_included_objects.key?(code)
             known_included_objects[code] = inc_obj
-            included_records << serializer.record_hash(inc_obj)
+            included_records << serializer.record_hash(inc_obj, included_fields)
           end
         end
       end

--- a/spec/lib/object_serializer_spec.rb
+++ b/spec/lib/object_serializer_spec.rb
@@ -8,6 +8,9 @@ describe FastJsonapi::ObjectSerializer do
       options = {}
       options[:meta] = { total: 2 }
       options[:include] = [:actors]
+      options[:fields] = {
+        actor: ['name']
+      }
       serializable_hash = MovieSerializer.new([movie, movie], options).serializable_hash
 
       expect(serializable_hash[:data].length).to eq 2
@@ -18,6 +21,7 @@ describe FastJsonapi::ObjectSerializer do
 
       expect(serializable_hash[:included]).to be_instance_of(Array)
       expect(serializable_hash[:included][0]).to be_instance_of(Hash)
+      expect(serializable_hash[:included][0][:attributes].keys).to eq [:name]
       expect(serializable_hash[:included].length).to eq 3
 
       serializable_hash = MovieSerializer.new(movie).serializable_hash
@@ -34,6 +38,17 @@ describe FastJsonapi::ObjectSerializer do
       serializable_hash = JSON.parse(json)
       expect(serializable_hash['data'].length).to eq 2
       expect(serializable_hash['meta']).to be_instance_of(Hash)
+    end
+
+    it 'returns correct fieldset when serializer instantiated with fields option' do
+      options = {
+        fields: {
+          movie: ['name']
+        }
+      }
+      json = MovieSerializer.new(movie, options).serialized_json
+      serializable_hash = JSON.parse(json)
+      expect(serializable_hash['data']['attributes'].keys).to eq ['name']
     end
 
     it 'returns correct id when serialized_json is called for a single object' do

--- a/spec/lib/object_serializer_spec.rb
+++ b/spec/lib/object_serializer_spec.rb
@@ -43,12 +43,14 @@ describe FastJsonapi::ObjectSerializer do
     it 'returns correct fieldset when serializer instantiated with fields option' do
       options = {
         fields: {
-          movie: ['name']
+          movie: ['name', 'actors']
         }
       }
       json = MovieSerializer.new(movie, options).serialized_json
       serializable_hash = JSON.parse(json)
+
       expect(serializable_hash['data']['attributes'].keys).to eq ['name']
+      expect(serializable_hash['data']['relationships'].keys).to eq ['actors']
     end
 
     it 'returns correct id when serialized_json is called for a single object' do

--- a/spec/lib/serialization_core_spec.rb
+++ b/spec/lib/serialization_core_spec.rb
@@ -74,8 +74,9 @@ describe FastJsonapi::ObjectSerializer do
       includes_list = [:actors]
       known_included_objects = {}
       included_records = []
+      fields = {}
       [movie, movie].each do |record|
-        included_records.concat MovieSerializer.send(:get_included_records, record, includes_list, known_included_objects)
+        included_records.concat MovieSerializer.send(:get_included_records, record, includes_list, fields, known_included_objects)
       end
       expect(included_records.size).to eq 3
     end

--- a/spec/lib/serialization_core_spec.rb
+++ b/spec/lib/serialization_core_spec.rb
@@ -41,13 +41,13 @@ describe FastJsonapi::ObjectSerializer do
     it 'returns the correct empty result when relationships_hash is called' do
       movie.actor_ids = []
       movie.owner_id = nil
-      relationships_hash = MovieSerializer.send(:relationships_hash, movie)
+      relationships_hash = MovieSerializer.send(:relationships_hash, movie, nil)
       expect(relationships_hash[:actors][:data]).to eq([])
       expect(relationships_hash[:owner][:data]).to eq(nil)
     end
 
     it 'returns correct keys when relationships_hash is called' do
-      relationships_hash = MovieSerializer.send(:relationships_hash, movie)
+      relationships_hash = MovieSerializer.send(:relationships_hash, movie, nil)
       relationship_names = relationships_hash.keys.sort
       relationships_hashes = MovieSerializer.relationships_to_serialize.values
       expected_names = relationships_hashes.map{|relationship| relationship[:key]}.sort
@@ -55,7 +55,7 @@ describe FastJsonapi::ObjectSerializer do
     end
 
     it 'returns correct values when relationships_hash is called' do
-      relationships_hash = MovieSerializer.relationships_hash(movie)
+      relationships_hash = MovieSerializer.relationships_hash(movie, nil)
       actors_hash = movie.actor_ids.map { |id|  {id: id.to_s, type: :actor} }
       owner_hash = {id: movie.owner_id.to_s, type: :user}
       expect(relationships_hash[:actors][:data]).to match_array actors_hash


### PR DESCRIPTION
This PR addresses #57 
It provides support for sparse fieldsets per json-api spec. Usage:
```ruby
options = {}
options[:meta] = { total: 2 }
options[:include] = [:actors]
options[:fields] = {
  movie: ['name'], # will only include name attribute into attributes hash
  actor: ['email'] # ...only email for included actors
}
MovieSerializer.new([movie, movie], options).serialized_json
```