### PR TITLE
add optional attributes

### DIFF
--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -159,11 +159,18 @@ module FastJsonapi
 
       def attributes(*attributes_list, &block)
         attributes_list = attributes_list.first if attributes_list.first.class.is_a?(Array)
+        options = attributes_list.last.is_a?(Hash) ? attributes_list.pop : {}
         self.attributes_to_serialize = {} if self.attributes_to_serialize.nil?
+        self.optional_attributes_to_serialize = {} if self.optional_attributes_to_serialize.nil?
+
         attributes_list.each do |attr_name|
           method_name = attr_name
           key = run_key_transform(method_name)
-          attributes_to_serialize[key] = block || method_name
+          if options[:if].present?
+            optional_attributes_to_serialize[key] = [method_name, options[:if]]
+          else
+            attributes_to_serialize[key] = block || method_name
+          end
         end
       end
 

--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -77,7 +77,17 @@ module FastJsonapi
 
       if options[:include].present?
         @includes = options[:include].delete_if(&:blank?).map(&:to_sym)
-        self.class.validate_includes!(@includes)
+        validate_includes!(@includes)
+      end
+    end
+
+    def validate_includes!(includes)
+      return if includes.blank?
+
+      existing_relationships = self.class.relationships_to_serialize.keys.to_set
+
+      unless existing_relationships.superset?(includes.to_set)
+        raise ArgumentError, "One of keys from #{includes} is not specified as a relationship on the serializer"
       end
     end
 

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -12,6 +12,7 @@ module FastJsonapi
     included do
       class << self
         attr_accessor :attributes_to_serialize,
+                      :optional_attributes_to_serialize,
                       :relationships_to_serialize,
                       :cachable_relationships_to_serialize,
                       :uncachable_relationships_to_serialize,
@@ -73,13 +74,21 @@ module FastJsonapi
       end
 
       def attributes_hash(record, params = {})
-        attributes_to_serialize.each_with_object({}) do |(key, method), attr_hash|
+        attributes = attributes_to_serialize.each_with_object({}) do |(key, method), attr_hash|
           attr_hash[key] = if method.is_a?(Proc)
             method.arity == 1 ? method.call(record) : method.call(record, params)
           else
             record.public_send(method)
           end
         end
+
+        self.optional_attributes_to_serialize = {} if self.optional_attributes_to_serialize.nil?
+        optional_attributes_to_serialize.each do |key, details|
+          method_name, check_proc = details
+          attributes[key] = record.send(method_name) if check_proc.call(record)
+        end
+
+        attributes
       end
 
       def relationships_hash(record, relationships = nil, params = {})

--- a/spec/lib/object_serializer_performance_spec.rb
+++ b/spec/lib/object_serializer_performance_spec.rb
@@ -33,6 +33,9 @@ describe FastJsonapi::ObjectSerializer, performance: true do
     }
   }
 
+  before(:all) { GC.disable }
+  after(:all) { GC.enable }
+
   context 'when testing performance of serialization' do
     it 'should create a hash of 1000 records in less than 50 ms' do
       movies = 1000.times.map { |_i| movie }

--- a/spec/lib/object_serializer_spec.rb
+++ b/spec/lib/object_serializer_spec.rb
@@ -302,4 +302,20 @@ describe FastJsonapi::ObjectSerializer do
       expect(serializable_hash[:included][0][:links][:self]).to eq url
     end
   end
+
+  context 'optional attributes' do
+    it 'returns optional attribute when attribute is included' do
+      movie.release_year = 2001
+      json = MovieOptionalSerializer.new(movie).serialized_json
+      serializable_hash = JSON.parse(json)
+      expect(serializable_hash['data']['attributes']['release_year']).to eq movie.release_year
+    end
+
+    it "doesn't returns optional attribute when attribute is not included" do
+      movie.release_year = 1970
+      json = MovieOptionalSerializer.new(movie).serialized_json
+      serializable_hash = JSON.parse(json)
+      expect(serializable_hash['data']['attributes'].has_key?('release_year')).to be_falsey
+    end
+  end
 end

--- a/spec/shared/contexts/movie_context.rb
+++ b/spec/shared/contexts/movie_context.rb
@@ -261,6 +261,13 @@ RSpec.shared_context 'movie class' do
       set_type :account
       belongs_to :supplier
     end
+
+    class MovieOptionalSerializer
+      include FastJsonapi::ObjectSerializer
+      set_type :movie
+      attributes :name
+      attribute :release_year, if: Proc.new { |record| record.release_year >= 2000 }
+    end
   end
 
 


### PR DESCRIPTION
In ActiveModelSerializer you can write code like this:

```ruby
class MovieSerializer < ActiveModel::Serializer
  attributes :id, :name
  attribute :release_year, if: :millenium_movie?

  def millenium_movie?
    object.release_year >= 2000
  end
end
```

That's a bit of a weird example (fitting it in to your Movie context), but we use it in our API to only return certain attributes if requested by an administrator key.

So I've made a PR adding similar functionality to FastJsonApi:

```ruby
    class MovieOptionalSerializer
      include FastJsonapi::ObjectSerializer

      attributes :name
      attribute :release_year, if: Proc.new { |record| record.release_year >= 2000 }
    end
```

What do you think? Merge or drop it?

It's the only thing I think that's holding us up from adopting FastJsonApi.