### PR TITLE
Add a generator for Rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Fast JSON API serialized 250 records in 3.01 ms
 * [Features](#features)
 * [Installation](#installation)
 * [Usage](#usage)
+  * [Rails Generator](#rails-generator)
   * [Model Definition](#model-definition)
   * [Serializer Definition](#serializer-definition)
   * [Object Serialization](#object-serialization)
@@ -54,6 +55,14 @@ $ bundle install
 ```
 
 ## Usage
+
+### Rails Generator
+You can use the bundled generator if you are using the library inside of
+a Rails project:
+
+    rails g Serializer Movie name year
+
+This will create a new serializer in `app/serializers/movie_serializer.rb`
 
 ### Model Definition
 

--- a/lib/generators/serializer/USAGE
+++ b/lib/generators/serializer/USAGE
@@ -1,0 +1,8 @@
+Description:
+    Generates a serializer for the given model.
+
+Example:
+    rails generate serializer Movie
+
+    This will create:
+        app/serializers/movie_serializer.rb

--- a/lib/generators/serializer/serializer_generator.rb
+++ b/lib/generators/serializer/serializer_generator.rb
@@ -1,0 +1,17 @@
+require 'rails/generators/base'
+
+class SerializerGenerator < Rails::Generators::NamedBase
+  source_root File.expand_path('templates', __dir__)
+
+  argument :attributes, type: :array, default: [], banner: 'field field'
+
+  def create_serializer_file
+    template 'serializer.rb.tt', File.join('app', 'serializers', class_path, "#{file_name}_serializer.rb")
+  end
+
+  private
+
+    def attributes_names
+      attributes.map { |a| a.name.to_sym.inspect }
+    end
+end

--- a/lib/generators/serializer/templates/serializer.rb.tt
+++ b/lib/generators/serializer/templates/serializer.rb.tt
@@ -1,0 +1,6 @@
+<% module_namespacing do -%>
+class <%= class_name %>Serializer
+  include FastJsonapi::ObjectSerializer
+  attributes <%= attributes_names.join(", ") %>
+end
+<% end -%>


### PR DESCRIPTION
This adds a generator that can be easily used in Rails projects:

Example:

        rails generate serializer Movie name year

Will create:

         app/serializers/movie_serializer.rb

with the next content:

```ruby
class MovieSerializer
  include FastJsonapi::ObjectSerializer
  attributes :name, :year
end
```