### PR TITLE
Allow the use of fast_jsonapi when ActiveRecord isn't present

### DIFF
--- a/lib/extensions/has_one.rb
+++ b/lib/extensions/has_one.rb
@@ -1,16 +1,20 @@
-require 'active_record'
+begin
+  require 'active_record'
 
-::ActiveRecord::Associations::Builder::HasOne.class_eval do
-  # Based on
-  # https://github.com/rails/rails/blob/master/activerecord/lib/active_record/associations/builder/collection_association.rb#L50
-  # https://github.com/rails/rails/blob/master/activerecord/lib/active_record/associations/builder/singular_association.rb#L11
-  def self.define_accessors(mixin, reflection)
-    super
-    name = reflection.name
-    mixin.class_eval <<-CODE, __FILE__, __LINE__ + 1
-      def #{name.to_s}_id
-        association(:#{name}).reader.try(:id)
-      end
-    CODE
+  ::ActiveRecord::Associations::Builder::HasOne.class_eval do
+    # Based on
+    # https://github.com/rails/rails/blob/master/activerecord/lib/active_record/associations/builder/collection_association.rb#L50
+    # https://github.com/rails/rails/blob/master/activerecord/lib/active_record/associations/builder/singular_association.rb#L11
+    def self.define_accessors(mixin, reflection)
+      super
+      name = reflection.name
+      mixin.class_eval <<-CODE, __FILE__, __LINE__ + 1
+        def #{name.to_s}_id
+          association(:#{name}).reader.try(:id)
+        end
+      CODE
+    end
   end
+rescue LoadError
+  # active_record can't be loaded so we shouldn't try to monkey-patch it.
 end


### PR DESCRIPTION
Trying to use fast_jsonapi dev branch in projects without ActiveRecord currently raises this error:

```
/Users/guillermo-iguaran/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/bundler/gems/fast_jsonapi-b30a53bc5fcf/lib/extensions/has_one.rb:1:in `require': cannot load such file -- active_record (LoadError)
	from /Users/guillermo-iguaran/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/bundler/gems/fast_jsonapi-b30a53bc5fcf/lib/extensions/has_one.rb:1:in `<top (required)>'
	from /Users/guillermo-iguaran/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/bundler/gems/fast_jsonapi-b30a53bc5fcf/lib/fast_jsonapi.rb:3:in `require'
	from /Users/guillermo-iguaran/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/bundler/gems/fast_jsonapi-b30a53bc5fcf/lib/fast_jsonapi.rb:3:in `<module:FastJsonapi>'
	from /Users/guillermo-iguaran/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/bundler/gems/fast_jsonapi-b30a53bc5fcf/lib/fast_jsonapi.rb:1:in `<top (required)>'
```

The reason is that the Active Record extension is required always, even for projects where Active Record isn't present.

This PR makes the AR extension optional allowing the use of the library when AR isn't present 