### PR TITLE
refactor performance specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,18 @@ We use [RSpec](http://rspec.info/) for testing. We have unit tests, functional t
 rspec
 ```
 
+To run tests without the performance tests (for quicker test runs):
+
+```bash
+rspec spec --tag ~performance:true
+```
+
+To run tests only performance tests:
+
+```bash
+rspec spec --tag performance:true
+```
+
 ### We're Hiring!
 
 Join the Netflix Studio Engineering team and help us build gems like this!


### PR DESCRIPTION
I added a few things around the performance specs.

1) The data that was being printed for the performance specs was not the same as being used for the `expect` statements. Each benchmark was being run twice, once for the `expect` and once for the printed stats.

2) I added some info to the stats message. It now looks like:
```
Serialize to JSON string 1 with polymorphic has_many
Serializer             Records    Time       Speed Up
Fast serializer        1          0.16 ms
AMS serializer         1          1.05 ms    6.71x ✘
jsonapi-rb serializer  1          0.15 ms    0.94x ✘
jsonapi-serializers    1          0.08 ms    0.49x ✘

Serialize to JSON string 1000 with polymorphic has_many
Serializer             Records    Time       Speed Up
Fast serializer        1000       10.98 ms
AMS serializer         1000       324.36 ms  29.55x ✔
jsonapi-rb serializer  1000       42.87 ms   3.91x ✔
jsonapi-serializers    1000       22.89 ms   2.09x ✔
```
Speed factor comparison defaults to 1.

3) I renamed things from `our_*` to `fast_jsonapi_*` to be more explicit.
4) Pulled out metadata for serializers into a constant, makes it easier to add more comparisons.
5) Updated `README` with info on running/not running performance specs.