### PR TITLE
Add #to_hash conversion protocol to object serializer

### DIFF
--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -42,6 +42,7 @@ module FastJsonapi
 
       hash_for_one_record
     end
+    alias_method :to_hash, :serializable_hash
 
     def hash_for_one_record
       serializable_hash = { data: nil }


### PR DESCRIPTION
# Problem

In order to use a serializer with Rails, you have to explicitly call `serialize_hash`, e.g.

```ruby
render json: WidgetSerializer.new(widget).serialized_hash
```

# Solution

While not a big problem at all, Rails does [use the `to_hash` protocol under the hood](https://github.com/rails/rails/blob/9c5c0596f137c396b6356416a3f92a3a082c53f6/activesupport/lib/active_support/core_ext/object/json.rb#L52-L58) in it's `as_json` core extension to Object. By implementing this interface you can conveniently pass a serializer instance directly to Rails' `render` method.

```ruby
render json: WidgetSerializer.new(widget)
```

This may have already been considered and explicitly omitted from the library, but I didn't see any past issues mentioning it, so I thought I'd propose the change 🙂

I'm happy to discuss more and make changes as needed. I considered adding a test, but it seemed relatively low value, and I wasn't sure of the ideal location for such a test. Thanks for the wonderfully useful little library! :heart::yellow_heart::green_heart::blue_heart: