### PR TITLE
Make an error that demonstrates https://github.com/Netflix/fast_jsonapi/issues/91

### DIFF
--- a/spec/lib/object_serializer_spec.rb
+++ b/spec/lib/object_serializer_spec.rb
@@ -90,6 +90,20 @@ describe FastJsonapi::ObjectSerializer do
       options[:include] = [nil]
       expect(MovieSerializer.new([movie, movie], options).serializable_hash.keys).to eq [:data, :meta]
     end
+
+    # this fails
+    it 'does not throw an error with non-empty string array includes key' do
+      options = {}
+      options[:include] = ['actors']
+      expect { MovieSerializer.new(movie, options) }.not_to raise_error
+    end
+
+    # this passes
+    it 'does not throw an error with a symbol array includes key' do
+      options = {}
+      options[:include] = [:actors]
+      expect { MovieSerializer.new(movie, options) }.not_to raise_error
+    end
   end
 
   context 'when testing included do block of object serializer' do


### PR DESCRIPTION
* #91 suggests includes cannot be strings
* Here's a simple RSpec test that fails with a non-empty string but passes with a
non-empty symbol
* To run the test, `rspec spec/lib/object_serializer_spec.rb`