### PR TITLE
Fix gemspec, README.rdoc isn't present in the project

### DIFF
--- a/fast_jsonapi.gemspec
+++ b/fast_jsonapi.gemspec
@@ -11,8 +11,7 @@ Gem::Specification.new do |gem|
   gem.email = ""
   gem.extra_rdoc_files = [
     "LICENSE.txt",
-    "README.md",
-    "README.rdoc"
+    "README.md"
   ]
   gem.files = Dir["lib/**/*"]
   gem.homepage = "http://github.com/Netflix/fast_jsonapi"


### PR DESCRIPTION
Trying to build the gem in `dev` branch I got an error:

```
~/src/fast_jsonapi[dev] % gem build fast_jsonapi.gemspec
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
ERROR:  While executing gem ... (Gem::InvalidSpecificationException)
    ["README.rdoc"] are not files
```

The reason is that the project doesn't have a README.rdoc but the file is listed in the gemspec so I've removed it from gemspec.