### PR TITLE
Switch serializers to use embeded MultiJSON

### DIFF
--- a/spec/shared/contexts/js_context.rb
+++ b/spec/shared/contexts/js_context.rb
@@ -61,7 +61,7 @@ RSpec.shared_context 'jsonapi-serializers movie class' do
       end
 
       def to_json
-        JSONAPI::Serializer.serialize(@data, @options).to_json
+        FastJsonapi::MultiToJson.to_json(JSONAPI::Serializer.serialize(@data, @options))
       end
 
       def to_hash

--- a/spec/shared/contexts/js_group_context.rb
+++ b/spec/shared/contexts/js_group_context.rb
@@ -38,7 +38,7 @@ RSpec.shared_context 'jsonapi-serializers group class' do
       end
 
       def to_json
-        JSON.fast_generate(to_hash)
+        FastJsonapi::MultiToJson.to_json(to_hash)
       end
 
       def to_hash

--- a/spec/shared/contexts/jsonapi_context.rb
+++ b/spec/shared/contexts/jsonapi_context.rb
@@ -55,7 +55,7 @@ RSpec.shared_context 'jsonapi movie class' do
       end
 
       def to_json
-        @serializer.render(@data, @options).to_json
+        FastJsonapi::MultiToJson.to_json(@serializer.render(@data, @options))
       end
 
       def to_hash

--- a/spec/shared/contexts/jsonapi_group_context.rb
+++ b/spec/shared/contexts/jsonapi_group_context.rb
@@ -34,7 +34,7 @@ RSpec.shared_context 'jsonapi group class' do
       end
 
       def to_json
-        @serializer.render(@data, @options).to_json
+        FastJsonapi::MultiToJson.to_json(@serializer.render(@data, @options))
       end
 
       def to_hash


### PR DESCRIPTION
As noted in https://github.com/Netflix/fast_jsonapi/issues/44, other JSON API serializers aren't using same JSON enconder as `fast_jsonapi`, this change the serializers to use same enconder.