### PR TITLE
Better benchmarks using existing method

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in fast_jsonapi.gemspec
 gemspec
+
+gem 'oj_mimic_json'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,7 @@ GEM
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
     oj (3.4.0)
+    oj_mimic_json (1.0.1)
     rack (2.0.3)
     rack-test (0.8.2)
       rack (>= 1.0, < 3)
@@ -108,6 +109,7 @@ DEPENDENCIES
   jsonapi-rb (~> 0.5.0)
   jsonapi-serializers (~> 1.0.0)
   oj (~> 3.3)
+  oj_mimic_json
   rspec (~> 3.5.0)
   rspec-benchmark (~> 0.3.0)
   skylight (~> 1.3)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,9 +11,10 @@ Dir[File.dirname(__FILE__) + '/shared/contexts/*.rb'].each {|file| require file 
 
 RSpec.configure do |config|
   config.include RSpec::Benchmark::Matchers
-  if ENV['TRAVIS'] == 'true' || ENV['TRAVIS'] == true
-    config.filter_run_excluding performance: true
-  end
+  # For the PR, show the benchmarks.
+  # if ENV['TRAVIS'] == 'true' || ENV['TRAVIS'] == true
+  #   config.filter_run_excluding performance: true
+  # end
 end
 
 Oj.optimize_rails

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,9 +2,10 @@ require 'fast_jsonapi'
 require 'rspec-benchmark'
 require 'byebug'
 require 'active_model_serializers'
-require 'oj'
 require 'jsonapi/serializable'
 require 'jsonapi-serializers'
+require 'oj'
+require 'oj_mimic_json'
 
 Dir[File.dirname(__FILE__) + '/shared/contexts/*.rb'].each {|file| require file }
 
@@ -17,5 +18,6 @@ end
 
 Oj.optimize_rails
 ActiveModel::Serializer.config.adapter = :json_api
-ActiveModel::Serializer.config.key_transform = :underscore
-ActiveModelSerializers.logger = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new('/dev/null'))
+ActiveModel::Serializer.config.key_transform = :unaltered
+# ActiveModelSerializers.logger = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new('/dev/null'))
+ActiveSupport::Notifications.unsubscribe(ActiveModelSerializers::Logging::RENDER_EVENT)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,5 +19,5 @@ end
 Oj.optimize_rails
 ActiveModel::Serializer.config.adapter = :json_api
 ActiveModel::Serializer.config.key_transform = :unaltered
-# ActiveModelSerializers.logger = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new('/dev/null'))
+ActiveModelSerializers.logger = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new('/dev/null'))
 ActiveSupport::Notifications.unsubscribe(ActiveModelSerializers::Logging::RENDER_EVENT)


### PR DESCRIPTION
I'm not a huge fan of AMS, but it's a diservice to claim 25x when AMS, by default is underscored (because ruby / ActiveRecord is underscored, so telling to to perform additional transformations is cheating a bit).

Additionally, here are results with and without oj_mimic_json:

with
```
bundle exec rspec ./spec/lib/object_serializer_performance_spec.rb[1:3:4]
Run options: include {:ids=>{"./spec/lib/object_serializer_performance_spec.rb"=>["1:3:4"]}}

Serialize to JSON string 1000 with includes and meta
Serializer             Records    Time       Speed Up
Fast serializer        1000       28.13 ms  
AMS serializer         1000       439.81 ms  15.63x ✘
jsonapi-rb serializer  1000       98.9 ms    3.52x ✔
jsonapi-serializers    1000       133.2 ms   4.73x ✔

Serialize to Ruby Hash 1000 with includes and meta
Serializer             Records    Time       Speed Up
Fast serializer        1000       24.31 ms  
AMS serializer         1000       406.64 ms  16.73x ✘
jsonapi-rb serializer  1000       95.43 ms   3.93x ✔
jsonapi-serializers    1000       126.03 ms  5.18x ✔

```

without
```
bundle exec rspec ./spec/lib/object_serializer_performance_spec.rb[1:3:4]
Run options: include {:ids=>{"./spec/lib/object_serializer_performance_spec.rb"=>["1:3:4"]}}

Serialize to JSON string 1000 with includes and meta
Serializer             Records    Time       Speed Up
Fast serializer        1000       35.42 ms  
AMS serializer         1000       453.29 ms  12.8x ✘
jsonapi-rb serializer  1000       99.6 ms    2.81x ✔
jsonapi-serializers    1000       131.6 ms   3.72x ✔

Serialize to Ruby Hash 1000 with includes and meta
Serializer             Records    Time       Speed Up
Fast serializer        1000       23.02 ms  
AMS serializer         1000       428.47 ms  18.61x ✘
jsonapi-rb serializer  1000       94.08 ms   4.09x ✔
jsonapi-serializers    1000       127.92 ms  5.56x ✔

```