### PR TITLE
Title fixed for one spec

### DIFF
--- a/OSSMETADATA
+++ b/OSSMETADATA
@@ -1,0 +1,1 @@
+osslifecycle=active

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A lightning fast [JSON:API](http://jsonapi.org/) serializer for Ruby Objects.
 
 # Performance Comparison
 
-We compare serialization times with Active Model Serializer as part of RSpec performance tests included on this library. We want to ensure that with every change on this library, serialization time is at least `25 times` faster than Active Model Serializers on up to current benchmark of 1000 records.
+We compare serialization times with Active Model Serializer as part of RSpec performance tests included on this library. We want to ensure that with every change on this library, serialization time is at least `25 times` faster than Active Model Serializers on up to current benchmark of 1000 records. Please read the [performance document](https://github.com/Netflix/fast_jsonapi/blob/master/performance_methodology.md) for any questions related to methodology.
 
 ## Benchmark times for 250 records
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fast JSON API
 
-[![NetflixOSS Lifecycle](https://img.shields.io/osslifecycle/Netflix/osstracker.svg)]()
+[![Build Status](https://travis-ci.org/Netflix/fast_jsonapi.svg?branch=master)](https://travis-ci.org/Netflix/fast_jsonapi)
 
 A lightning fast [JSON:API](http://jsonapi.org/) serializer for Ruby Objects.
 
@@ -178,7 +178,7 @@ serializer | Set custom Serializer for a relationship | ```has_many :actors, ser
 
 ## Contributing
 
-Please follow the steps on [contribution checklist](https://github.com/Netflix/fast_jsonapi/blob/master/CONTRIBUTING.md).
+Please follow the steps on [contribution check](https://github.com/Netflix/fast_jsonapi/blob/master/CONTRIBUTING.md).
 This gem is built using a gem building gem called [juwelier](https://github.com/flajann2/juwelier).
 
 Beyond just editing source code, you’ll be interacting with the gem using rake a lot. To see all the tasks available with a brief description, you can run:

--- a/performance_methodology.md
+++ b/performance_methodology.md
@@ -1,0 +1,44 @@
+# Performance using Fast JSON API
+
+We have been getting a few questions on Github about [Fast JSON API’s](https://github.com/Netflix/fast_jsonapi) performance statistics and the methodology used to measure the performance. This article is an attempt at addressing this aspect of the gem.  
+
+## Prologue
+
+With use cases like infinite scroll on complex models and bulk update on index pages, we started observing performance degradation on our Rails APIs. Our first step was to enable instrumentation and then tune for performance. We realized that, on average, more than 50% of the time was being spent on AMS serialization. At the same time, we had a couple of APIs that were simply proxying requests on top of a non-Rails, non-JSON API endpoint. Guess what? The non-Rails endpoints were giving us serialized JSON back in a fraction of the time spent by AMS.
+
+This led us to explore AMS documentation in depth in an effort to try a variety of techniques such as caching, using OJ for JSON string generation etc. It didn’t yield the consistent results we were hoping to get. We loved the developer experience of using AMS, but wanted better performance for our use cases.
+
+We came up with patterns that we can rely upon such as:
+
+* We always use [JSON:API](http://jsonapi.org/) for our APIs
+* We almost always serialize a homogenous list of objects (Example: An array of movies)
+
+On the other hand:
+
+* AMS is designed to serialize JSON in several different formats, not just JSON:API
+* AMS can also handle lists that are not homogenous
+
+This led us to build our own object serialization library that would be faster because it would be tailored to our requirements. The usage of fast_jsonapi internally on production environments resulted in significant performance gains.
+
+## Benchmark Setup
+
+The benchmark setup is simple with classes for ``` Movie, Actor, MovieType, User ``` on ```movie_context.rb``` for fast_jsonapi serializers and on ```ams_context.rb``` for AMS serializers. We benchmark the serializers with ```1, 25, 250, 1000``` movies, then we output the result. We also ensure that JSON string output is equivalent to ensure neither library is doing excess work compared to the other. Please checkout [object_serializer_performance_spec](https://github.com/Netflix/fast_jsonapi/blob/master/spec/lib/object_serializer_performance_spec.rb).
+
+## Benchmark Results
+
+We benchmarked results for creating a Ruby Hash. This approach removes the effect of chosen JSON string generation engines like OJ, Yajl etc. Benchmarks indicate that fast_jsonapi consistently performs around ```25 times``` faster than AMS in generating a ruby hash.
+
+We applied a similar benchmark on the operation to serialize the objects to a JSON string. This approach helps with ensuring some important criterias, such as:
+
+* OJ is used as the JSON engine for benchmarking both AMS and fast_jsonapi
+* The benchmark is easy to understand
+* The benchmark helps to improve performance
+* The benchmark influences design decisions for the gem  
+
+This gem is currently used in several APIs at Netflix and has reduced the response times by more than half on many of these APIs. We truly appreciate the Ruby and Rails communities and wanted to contribute in an effort to help improve the performance of your APIs too.
+
+## Epilogue
+
+[Fast JSON API](https://github.com/Netflix/fast_jsonapi) is not a replacement for AMS. AMS is a great gem, and it does many things and is very flexible. We still use it for non JSON:API serialization and deserialization. What started off as an internal performance exercise evolved into fast_jsonapi and created an opportunity to give something back to the awesome **Ruby and Rails communities**.
+
+We are excited to share it with all of you since we believe that there will be **no** end to this need for speed on APIs. :)

--- a/spec/lib/object_serializer_performance_spec.rb
+++ b/spec/lib/object_serializer_performance_spec.rb
@@ -34,12 +34,28 @@ describe FastJsonapi::ObjectSerializer, performance: true do
     end
   end
 
-  def print_stats(count, ams_time, our_time)
+  def print_stats(message, count, ams_time, our_time)
     format = '%-15s %-10s %s'
     puts ''
+    puts message
     puts format(format, 'Serializer', 'Records', 'Time')
     puts format(format, 'AMS serializer', count, ams_time.round(2).to_s + ' ms')
     puts format(format, 'Fast serializer', count, our_time.round(2).to_s + ' ms')
+  end
+
+  def run_hash_benchmark(message, movie_count, our_serializer, ams_serializer)
+    our_time = Benchmark.measure { our_hash = our_serializer.serializable_hash }.real * 1000
+    ams_time = Benchmark.measure { ams_hash = ams_serializer.as_json }.real * 1000
+    print_stats(message, movie_count, ams_time, our_time)
+  end
+
+  def run_json_benchmark(message, movie_count, our_serializer, ams_serializer)
+    our_json = nil
+    ams_json = nil
+    our_time = Benchmark.measure { our_json = our_serializer.serialized_json }.real * 1000
+    ams_time = Benchmark.measure { ams_json = ams_serializer.to_json }.real * 1000
+    print_stats(message, movie_count, ams_time, our_time)
+    return our_json, ams_json
   end
 
   context 'when comparing with AMS 0.10.x' do
@@ -48,15 +64,18 @@ describe FastJsonapi::ObjectSerializer, performance: true do
       it "should serialize #{movie_count} records atleast #{speed_factor} times faster than AMS" do
         ams_movies = build_ams_movies(movie_count)
         movies = build_movies(movie_count)
-        our_json = nil
-        ams_json = nil
         our_serializer = MovieSerializer.new(movies)
         ams_serializer = ActiveModelSerializers::SerializableResource.new(ams_movies)
-        our_time = Benchmark.measure { our_json = our_serializer.serialized_json }.real * 1000
-        ams_time = Benchmark.measure { ams_json = ams_serializer.to_json }.real * 1000
-        print_stats(movie_count, ams_time, our_time)
+
+        message = "Serialize to JSON string #{movie_count} records"
+        our_json, ams_json = run_json_benchmark(message, movie_count, our_serializer, ams_serializer)
+
+        message = "Serialize to Ruby Hash #{movie_count} records"
+        run_hash_benchmark(message, movie_count, our_serializer, ams_serializer)
+
         expect(our_json.length).to eq ams_json.length
         expect { our_serializer.serialized_json }.to perform_faster_than { ams_serializer.to_json }.at_least(speed_factor).times
+        expect { our_serializer.serializable_hash }.to perform_faster_than { ams_serializer.as_json }.at_least(speed_factor).times
       end
     end
   end
@@ -67,20 +86,21 @@ describe FastJsonapi::ObjectSerializer, performance: true do
       it "should serialize #{movie_count} records atleast #{speed_factor} times faster than AMS" do
         ams_movies = build_ams_movies(movie_count)
         movies = build_movies(movie_count)
-        our_json = nil
-        ams_json = nil
-
         options = {}
         options[:meta] = { total: movie_count }
         options[:include] = [:actors, :movie_type]
-
         our_serializer = MovieSerializer.new(movies, options)
         ams_serializer = ActiveModelSerializers::SerializableResource.new(ams_movies, include: options[:include], meta: options[:meta])
-        our_time = Benchmark.measure { our_json = our_serializer.serialized_json }.real * 1000
-        ams_time = Benchmark.measure { ams_json = ams_serializer.to_json }.real * 1000
-        print_stats(movie_count, ams_time, our_time)
+
+        message = "Serialize to JSON string #{movie_count} with includes and meta"
+        our_json, ams_json = run_json_benchmark(message, movie_count, our_serializer, ams_serializer)
+
+        message = "Serialize to Ruby Hash #{movie_count} with includes and meta"
+        run_hash_benchmark(message, movie_count, our_serializer, ams_serializer)
+
         expect(our_json.length).to eq ams_json.length
         expect { our_serializer.serialized_json }.to perform_faster_than { ams_serializer.to_json }.at_least(speed_factor).times
+        expect { our_serializer.serializable_hash }.to perform_faster_than { ams_serializer.as_json }.at_least(speed_factor).times
       end
     end
   end

--- a/spec/lib/object_serializer_performance_spec.rb
+++ b/spec/lib/object_serializer_performance_spec.rb
@@ -4,6 +4,9 @@ describe FastJsonapi::ObjectSerializer, performance: true do
   include_context 'movie class'
   include_context 'ams movie class'
 
+  before(:all) { GC.disable }
+  after(:all) { GC.enable }
+
   context 'when testing performance of serialization' do
     it 'should create a hash of 1000 records in less than 50 ms' do
       movies = 1000.times.map { |_i| movie }

--- a/spec/lib/object_serializer_spec.rb
+++ b/spec/lib/object_serializer_spec.rb
@@ -114,7 +114,7 @@ describe FastJsonapi::ObjectSerializer do
       expect(BlahBlahSerializerBuilder.record_type).to be_nil
     end
 
-    it 'shouldnt set default_type for a serializer that doesnt follow convention' do
+    it 'should set default_type for a namespaced serializer' do
       module V1
         class BlahSerializer
           include FastJsonapi::ObjectSerializer

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require 'rspec-benchmark'
 require 'multi_json'
 require 'byebug'
 require 'active_model_serializers'
+require 'oj'
 
 Dir[File.dirname(__FILE__) + '/shared/contexts/*.rb'].each {|file| require file }
 
@@ -13,6 +14,7 @@ RSpec.configure do |config|
   end
 end
 
+Oj.optimize_rails
 ActiveModel::Serializer.config.adapter = :json_api
 ActiveModel::Serializer.config.key_transform = :underscore
 ActiveModelSerializers.logger = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new('/dev/null'))


### PR DESCRIPTION
Title for spec testing that namespaced class gets proper default record_type was wrong (copied from previous spec).

https://github.com/Netflix/fast_jsonapi/blob/master/spec/lib/object_serializer_spec.rb#L117