### PR TITLE
Remove redundant to_s

### DIFF
--- a/lib/extensions/has_one.rb
+++ b/lib/extensions/has_one.rb
@@ -9,7 +9,7 @@ begin
       super
       name = reflection.name
       mixin.class_eval <<-CODE, __FILE__, __LINE__ + 1
-        def #{name.to_s}_id
+        def #{name}_id
           association(:#{name}).reader.try(:id)
         end
       CODE


### PR DESCRIPTION
I think this `to_s` inside `#{}` is redundant since it automatically calls `to_s`.
Thank you! 👍 