### PR TITLE
Adding some specs for #as_json on ObjectSerializer class.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,9 @@ doc
 
 # For the gem
 test.db
+
+# For those using rbenv
+.ruby-version
+
+# For those who install gems locally to a vendor dir
+/vendor

--- a/spec/lib/object_serializer_spec.rb
+++ b/spec/lib/object_serializer_spec.rb
@@ -82,6 +82,24 @@ describe FastJsonapi::ObjectSerializer do
       expect(serializable_hash['data']).to eq []
     end
 
+    describe '#as_json' do
+      it 'returns a json hash' do
+        json_hash = MovieSerializer.new(movie).as_json
+        expect(json_hash['data']['id']).to eq movie.id.to_s
+      end
+
+      it 'returns multiple records' do
+        json_hash = MovieSerializer.new([movie, movie]).as_json
+        expect(json_hash['data'].length).to eq 2
+      end
+
+      it 'removes non-relevant attributes' do
+        movie.director = 'steven spielberg'
+        json_hash = MovieSerializer.new(movie).as_json
+        expect(json_hash['data']['director']).to eq(nil)
+      end
+    end
+
     it 'returns errors when serializing with non-existent includes key' do
       options = {}
       options[:meta] = { total: 2 }

--- a/spec/shared/contexts/movie_context.rb
+++ b/spec/shared/contexts/movie_context.rb
@@ -4,7 +4,13 @@ RSpec.shared_context 'movie class' do
   before(:context) do
     # models
     class Movie
-      attr_accessor :id, :name, :release_year, :actor_ids, :owner_id, :movie_type_id
+      attr_accessor :id,
+                    :name, 
+                    :release_year,
+                    :director,
+                    :actor_ids, 
+                    :owner_id, 
+                    :movie_type_id
 
       def actors
         actor_ids.map do |id|
@@ -56,6 +62,7 @@ RSpec.shared_context 'movie class' do
     class MovieSerializer
       include FastJsonapi::ObjectSerializer
       set_type :movie
+      # director attr is not mentioned intentionally
       attributes :name, :release_year
       has_many :actors
       belongs_to :owner, record_type: :user
@@ -135,7 +142,14 @@ RSpec.shared_context 'movie class' do
   # Movie and Actor struct
   before(:context) do
     MovieStruct = Struct.new(
-      :id, :name, :release_year, :actor_ids, :actors, :owner_id, :owner, :movie_type_id
+      :id, 
+      :name, 
+      :release_year, 
+      :actor_ids, 
+      :actors, 
+      :owner_id, 
+      :owner, 
+      :movie_type_id
     )
 
     ActorStruct = Struct.new(:id, :name, :email)


### PR DESCRIPTION
Added some tests here to ensure that we are maintaining availability of the `as_json` method on our Object Serializer.

Allowing `as_json` to successfully parse a json hash on the serializer was added in this pull request:
https://github.com/Netflix/fast_jsonapi/pull/89

I added a director attr_accessor in the movie context that acts to prove if an attribute is present on the record but not defined in the serializer, it should not be returned.