### PR TITLE
Title fixed for one spec

### DIFF
--- a/spec/lib/object_serializer_spec.rb
+++ b/spec/lib/object_serializer_spec.rb
@@ -121,7 +121,7 @@ describe FastJsonapi::ObjectSerializer do
       expect(BlahBlahSerializerBuilder.record_type).to be_nil
     end
 
-    it 'shouldnt set default_type for a serializer that doesnt follow convention' do
+    it 'should set default_type for a namespaced serializer' do
       module V1
         class BlahSerializer
           include FastJsonapi::ObjectSerializer


### PR DESCRIPTION
Title for spec testing that namespaced class gets proper default record_type was wrong (copied from previous spec).

https://github.com/Netflix/fast_jsonapi/blob/master/spec/lib/object_serializer_spec.rb#L117