### PR TITLE
Remove redundant GC.disable and GC.enable

### DIFF
--- a/spec/lib/object_serializer_performance_spec.rb
+++ b/spec/lib/object_serializer_performance_spec.rb
@@ -33,9 +33,6 @@ describe FastJsonapi::ObjectSerializer, performance: true do
     }
   }
 
-  before(:all) { GC.disable }
-  after(:all) { GC.enable }
-
   context 'when testing performance of serialization' do
     it 'should create a hash of 1000 records in less than 50 ms' do
       movies = 1000.times.map { |_i| movie }


### PR DESCRIPTION
Removed redundant `before(:all) { GC.disable }` and `after(:all) { GC.enable }` since they are already defined above!