### PR TITLE
Enable to set id

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ end
 class MovieSerializer
   include FastJsonapi::ObjectSerializer
   set_type :movie  # optional
+  set_id :owner_id # optional
   attributes :name, :year
   has_many :actors
   belongs_to :owner, record_type: :user
@@ -114,7 +115,7 @@ json_string = MovieSerializer.new(movie).serialized_json
 ```json
 {
   "data": {
-    "id": "232",
+    "id": "3",
     "type": "movie",
     "attributes": {
       "name": "test movie",
@@ -238,6 +239,7 @@ end
 Option | Purpose | Example
 ------------ | ------------- | -------------
 set_type | Type name of Object | ```set_type :movie ```
+set_id | ID of Object | ```set_id :owner_id ```
 cache_options | Hash to enable caching and set cache length | ```cache_options enabled: true, cache_length: 12.hours```
 id_method_name | Set custom method name to get ID of an object | ```has_many :locations, id_method_name: :place_ids ```
 object_method_name | Set custom method name to get related objects | ```has_many :locations, object_method_name: :places ```

--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -123,6 +123,10 @@ module FastJsonapi
         self.record_type = run_key_transform(type_name)
       end
 
+      def set_id(id_name)
+        self.record_id = id_name
+      end
+
       def cache_options(cache_options)
         self.cached = cache_options[:enabled] || false
         self.cache_length = cache_options[:cache_length] || 5.minutes

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -14,6 +14,7 @@ module FastJsonapi
                       :cachable_relationships_to_serialize,
                       :uncachable_relationships_to_serialize,
                       :record_type,
+                      :record_id,
                       :cache_length,
                       :cached
       end
@@ -74,7 +75,8 @@ module FastJsonapi
       def record_hash(record)
         if cached
           record_hash = Rails.cache.fetch(record.cache_key, expires_in: cache_length) do
-            temp_hash = id_hash(record.id, record_type) || { id: nil, type: record_type }
+            id = record_id ? record.send(record_id) : record.id
+            temp_hash = id_hash(id, record_type) || { id: nil, type: record_type }
             temp_hash[:attributes] = attributes_hash(record) if attributes_to_serialize.present?
             temp_hash[:relationships] = {}
             temp_hash[:relationships] = relationships_hash(record, cachable_relationships_to_serialize) if cachable_relationships_to_serialize.present?
@@ -83,7 +85,8 @@ module FastJsonapi
           record_hash[:relationships] = record_hash[:relationships].merge(relationships_hash(record, uncachable_relationships_to_serialize)) if uncachable_relationships_to_serialize.present?
           record_hash
         else
-          record_hash = id_hash(record.id, record_type) || { id: nil, type: record_type }
+          id = record_id ? record.send(record_id) : record.id
+          record_hash = id_hash(id, record_type) || { id: nil, type: record_type }
           record_hash[:attributes] = attributes_hash(record) if attributes_to_serialize.present?
           record_hash[:relationships] = relationships_hash(record) if relationships_to_serialize.present?
           record_hash

--- a/spec/lib/object_serializer_set_id_spec.rb
+++ b/spec/lib/object_serializer_set_id_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe FastJsonapi::ObjectSerializer do
+  include_context 'movie class'
+
+  context 'when setting id' do
+    subject(:serializable_hash) { MovieSerializer.new(resource).serializable_hash }
+
+    before(:all) do
+      MovieSerializer.set_id :owner_id
+    end
+
+    context 'when one record is given' do
+      let(:resource) { movie }
+
+      it 'returns correct hash which id equals owner_id' do
+        expect(serializable_hash[:data][:id].to_i).to eq movie.owner_id
+      end
+    end
+
+    context 'when an array of records is given' do
+      let(:resource) { [movie, movie] }
+
+      it 'returns correct hash which id equals owner_id' do
+        expect(serializable_hash[:data][0][:id].to_i).to eq movie.owner_id
+        expect(serializable_hash[:data][1][:id].to_i).to eq movie.owner_id
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR relates to https://github.com/Netflix/fast_jsonapi/issues/113.
I implemented `FastJsonapi::ObjectSerializer#set_id` in order to set arbitrary column as `id`.

Thank you! 👍 