### PR TITLE
fix behaviour for struct without id

### DIFF
--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -22,7 +22,7 @@ module FastJsonapi
 
     class_methods do
       def id_hash(id, record_type)
-        return { id: id.to_s, type: record_type } if id.present?
+        { id: id.to_s, type: record_type } if id.present?
       end
 
       def ids_hash(ids, record_type)

--- a/spec/lib/object_serializer_struct_spec.rb
+++ b/spec/lib/object_serializer_struct_spec.rb
@@ -33,21 +33,8 @@ describe FastJsonapi::ObjectSerializer do
 
     context 'struct without id' do
       it 'returns correct hash when serializable_hash is called' do
-        options = {}
-        options[:meta] = { total: 2 }
-        serializable_hash = MovieWithoutIdStructSerializer.new([movie_struct_without_id, movie_struct_without_id], options).serializable_hash
-
-        expect(serializable_hash[:data].length).to eq 2
-        expect(serializable_hash[:data][0][:attributes].length).to eq 2
-        expect(serializable_hash[:meta]).to be_instance_of(Hash)
-
-        serializable_hash = MovieWithoutIdStructSerializer.new(movie_struct_without_id).serializable_hash
-
-        expect(serializable_hash[:data]).to be_instance_of(Hash)
-        expect(serializable_hash[:meta]).to be nil
-        expect(serializable_hash[:included]).to be nil
-        expect(serializable_hash[:data][:id]).to be nil
-        expect(serializable_hash[:data][:type]).to be nil
+        serializer = MovieWithoutIdStructSerializer.new(movie_struct_without_id)
+        expect { serializer.serializable_hash }.to raise_error(FastJsonapi::MandatoryField)
       end
     end
   end

--- a/spec/lib/object_serializer_struct_spec.rb
+++ b/spec/lib/object_serializer_struct_spec.rb
@@ -30,5 +30,25 @@ describe FastJsonapi::ObjectSerializer do
       expect(serializable_hash[:included]).to be nil
       expect(serializable_hash[:data][:id]).to eq movie_struct.id.to_s
     end
+
+    context 'struct without id' do
+      it 'returns correct hash when serializable_hash is called' do
+        options = {}
+        options[:meta] = { total: 2 }
+        serializable_hash = MovieWithoutIdStructSerializer.new([movie_struct_without_id, movie_struct_without_id], options).serializable_hash
+
+        expect(serializable_hash[:data].length).to eq 2
+        expect(serializable_hash[:data][0][:attributes].length).to eq 2
+        expect(serializable_hash[:meta]).to be_instance_of(Hash)
+
+        serializable_hash = MovieWithoutIdStructSerializer.new(movie_struct_without_id).serializable_hash
+
+        expect(serializable_hash[:data]).to be_instance_of(Hash)
+        expect(serializable_hash[:meta]).to be nil
+        expect(serializable_hash[:included]).to be nil
+        expect(serializable_hash[:data][:id]).to be nil
+        expect(serializable_hash[:data][:type]).to be nil
+      end
+    end
   end
 end

--- a/spec/shared/contexts/movie_context.rb
+++ b/spec/shared/contexts/movie_context.rb
@@ -5,11 +5,11 @@ RSpec.shared_context 'movie class' do
     # models
     class Movie
       attr_accessor :id,
-                    :name, 
+                    :name,
                     :release_year,
                     :director,
-                    :actor_ids, 
-                    :owner_id, 
+                    :actor_ids,
+                    :owner_id,
                     :movie_type_id
 
       def actors
@@ -67,6 +67,11 @@ RSpec.shared_context 'movie class' do
       has_many :actors
       belongs_to :owner, record_type: :user
       belongs_to :movie_type
+    end
+
+    class MovieWithoutIdStructSerializer
+      include FastJsonapi::ObjectSerializer
+      attributes :name, :release_year
     end
 
     class CachingMovieSerializer
@@ -142,17 +147,18 @@ RSpec.shared_context 'movie class' do
   # Movie and Actor struct
   before(:context) do
     MovieStruct = Struct.new(
-      :id, 
-      :name, 
-      :release_year, 
-      :actor_ids, 
-      :actors, 
-      :owner_id, 
-      :owner, 
+      :id,
+      :name,
+      :release_year,
+      :actor_ids,
+      :actors,
+      :owner_id,
+      :owner,
       :movie_type_id
     )
 
     ActorStruct = Struct.new(:id, :name, :email)
+    MovieWithoutIdStruct = Struct.new(:name, :release_year)
   end
 
   after(:context) do
@@ -167,7 +173,9 @@ RSpec.shared_context 'movie class' do
       AppName::V1::MovieSerializer
       MovieStruct
       ActorStruct
+      MovieWithoutIdStruct
       HyphenMovieSerializer
+      MovieWithoutIdStructSerializer
     ]
     classes_to_remove.each do |klass_name|
       Object.send(:remove_const, klass_name) if Object.constants.include?(klass_name)
@@ -191,6 +199,10 @@ RSpec.shared_context 'movie class' do
     m[:movie_type_id] = 2
     m[:actors] = actors
     m
+  end
+
+  let(:movie_struct_without_id) do
+    MovieWithoutIdStruct.new('struct without id', 2018)
   end
 
   let(:movie) do


### PR DESCRIPTION
```ruby
# test_id.rb
require "fast_jsonapi"

StructWithoutId = Struct.new(:name, :text)

class StructWithoutIdSerializer
  include FastJsonapi::ObjectSerializer

  attributes :name, :text
end

StructWithoutIdSerializer.new(StructWithoutId.new("test", "test")).serializable_hash
```

```bash
ruby test_id.rb
=> undefined method `id' for #<struct StructWithoutId name="test", text="test"> (NoMethodError)
```
This pull requests adds exception with explanation why id is mandatory field.


