### PR TITLE
adds the use_hyphen feature back and adds a deprecation warning

### DIFF
--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -119,6 +119,11 @@ module FastJsonapi
         end
       end
 
+      def use_hyphen
+        warn('DEPRECATION WARNING: use_hyphen is deprecated and will be removed from fast_jsonapi 2.0 use (set_key_transform :dash) instead')
+        set_key_transform :dash
+      end
+
       def set_type(type_name)
         self.record_type = run_key_transform(type_name)
       end

--- a/spec/lib/object_serializer_class_methods_spec.rb
+++ b/spec/lib/object_serializer_class_methods_spec.rb
@@ -64,6 +64,13 @@ describe FastJsonapi::ObjectSerializer do
       relationship = AppName::V1::MovieSerializer.relationships_to_serialize[:area]
       expect(relationship[:serializer]).to be :'AppName::V1::AreaSerializer'
     end
+
+    it 'sets the correct transform_method when use_hyphen is used' do
+      MovieSerializer.use_hyphen
+      warning_message = 'DEPRECATION WARNING: use_hyphen is deprecated and will be removed from fast_jsonapi 2.0 use (set_key_transform :dash) instead'
+      expect { MovieSerializer.use_hyphen }.to output.to_stderr
+      expect(MovieSerializer.instance_variable_get(:@transform_method)).to eq :dasherize
+    end
   end
 
 end


### PR DESCRIPTION
This adds backward compatibility to `use_hyphen` which would dasherize the keys and values of the output. The new approach to do it is to use `set_key_transform :dash`