### PR TITLE
Refactor object serializer class methods spec

### DIFF
--- a/spec/lib/object_serializer_class_methods_spec.rb
+++ b/spec/lib/object_serializer_class_methods_spec.rb
@@ -4,73 +4,94 @@ describe FastJsonapi::ObjectSerializer do
 
   include_context 'movie class'
 
-  context 'when testing class methods of object serializer' do
+  describe '#has_many' do
+    subject(:relationship) { serializer.relationships_to_serialize[:roles] }
 
-    before(:example) do
-      MovieSerializer.relationships_to_serialize = {}
+    before do
+      serializer.has_many *children
     end
 
-    it 'returns correct relationship hash for a has_many relationship' do
-      MovieSerializer.has_many :roles
-      relationship = MovieSerializer.relationships_to_serialize[:roles]
-      expect(relationship).to be_instance_of(Hash)
-      expect(relationship.keys).to all(be_instance_of(Symbol))
-      expect(relationship[:id_method_name]).to end_with '_ids'
-      expect(relationship[:record_type]).to eq 'roles'.singularize.to_sym
+    context 'with namespace' do
+      let(:serializer) { AppName::V1::MovieSerializer }
+      let(:children) { [:roles] }
+
+      context 'with overrides' do
+        let(:children) { [:roles, id_method_name: :roles_only_ids, record_type: :super_role] }
+
+        it_behaves_like 'returning correct relationship hash', :'AppName::V1::RoleSerializer', :roles_only_ids, :super_role
+      end
+
+      context 'without overrides' do
+        let(:children) { [:roles] }
+
+        it_behaves_like 'returning correct relationship hash', :'AppName::V1::RoleSerializer', :role_ids, :role
+      end
     end
 
-    it 'returns correct relationship hash for a has_many relationship with overrides' do
-      MovieSerializer.has_many :roles, id_method_name: :roles_only_ids, record_type: :super_role
-      relationship = MovieSerializer.relationships_to_serialize[:roles]
-      expect(relationship[:id_method_name]).to be :roles_only_ids
-      expect(relationship[:record_type]).to be :super_role
-    end
+    context 'without namespace' do
+      let(:serializer) { MovieSerializer }
 
-    it 'returns correct relationship hash for a belongs_to relationship' do
-      MovieSerializer.belongs_to :area
-      relationship = MovieSerializer.relationships_to_serialize[:area]
-      expect(relationship).to be_instance_of(Hash)
-      expect(relationship.keys).to all(be_instance_of(Symbol))
-      expect(relationship[:id_method_name]).to end_with '_id'
-      expect(relationship[:record_type]).to eq 'area'.singularize.to_sym
-    end
+      context 'with overrides' do
+        let(:children) { [:roles, id_method_name: :roles_only_ids, record_type: :super_role] }
 
-    it 'returns correct relationship hash for a belongs_to relationship with overrides' do
-      MovieSerializer.has_many :area, id_method_name: :blah_id, record_type: :awesome_area, serializer: :my_area
-      relationship = MovieSerializer.relationships_to_serialize[:area]
-      expect(relationship[:id_method_name]).to be :blah_id
-      expect(relationship[:record_type]).to be :awesome_area
-      expect(relationship[:serializer]).to be :MyAreaSerializer
-    end
+        it_behaves_like 'returning correct relationship hash', :'RoleSerializer', :roles_only_ids, :super_role
+      end
 
-    it 'returns correct relationship hash for a has_one relationship' do
-      MovieSerializer.has_one :area
-      relationship = MovieSerializer.relationships_to_serialize[:area]
-      expect(relationship).to be_instance_of(Hash)
-      expect(relationship.keys).to all(be_instance_of(Symbol))
-      expect(relationship[:id_method_name]).to end_with '_id'
-      expect(relationship[:record_type]).to eq 'area'.singularize.to_sym
-    end
+      context 'without overrides' do
+        let(:children) { [:roles] }
 
-    it 'returns correct relationship hash for a has_one relationship with overrides' do
-      MovieSerializer.has_one :area, id_method_name: :blah_id, record_type: :awesome_area
-      relationship = MovieSerializer.relationships_to_serialize[:area]
-      expect(relationship[:id_method_name]).to be :blah_id
-      expect(relationship[:record_type]).to be :awesome_area
-    end
-
-    it 'returns serializer name correctly with namespaces' do
-      AppName::V1::MovieSerializer.has_many :area, id_method_name: :blah_id
-      relationship = AppName::V1::MovieSerializer.relationships_to_serialize[:area]
-      expect(relationship[:serializer]).to be :'AppName::V1::AreaSerializer'
-    end
-
-    it 'sets the correct transform_method when use_hyphen is used' do
-      MovieSerializer.use_hyphen
-      warning_message = 'DEPRECATION WARNING: use_hyphen is deprecated and will be removed from fast_jsonapi 2.0 use (set_key_transform :dash) instead'
-      expect { MovieSerializer.use_hyphen }.to output.to_stderr
-      expect(MovieSerializer.instance_variable_get(:@transform_method)).to eq :dasherize
+        it_behaves_like 'returning correct relationship hash', :'RoleSerializer', :role_ids, :role
+      end
     end
   end
 
+  describe '#belongs_to' do
+    subject(:relationship) { MovieSerializer.relationships_to_serialize[:area] }
+
+    before do
+      MovieSerializer.belongs_to *parent
+    end
+
+    context 'with overrides' do
+      let(:parent) { [:area, id_method_name: :blah_id, record_type: :awesome_area, serializer: :my_area] }
+
+      it_behaves_like 'returning correct relationship hash', :'MyAreaSerializer', :blah_id, :awesome_area
+    end
+
+    context 'without overrides' do
+      let(:parent) { [:area] }
+
+      it_behaves_like 'returning correct relationship hash', :'AreaSerializer', :area_id, :area
+    end
+  end
+
+  describe '#has_one' do
+    subject(:relationship) { MovieSerializer.relationships_to_serialize[:area] }
+
+    before do
+      MovieSerializer.has_one *partner
+    end
+
+    context 'with overrides' do
+      let(:partner) { [:area, id_method_name: :blah_id, record_type: :awesome_area, serializer: :my_area] }
+
+      it_behaves_like 'returning correct relationship hash', :'MyAreaSerializer', :blah_id, :awesome_area
+    end
+
+    context 'without overrides' do
+      let(:partner) { [:area] }
+
+      it_behaves_like 'returning correct relationship hash', :'AreaSerializer', :area_id, :area
+    end
+  end
+
+  describe '#use_hyphen' do
+    subject { MovieSerializer.use_hyphen }
+
+    it 'sets the correct transform_method when use_hyphen is used' do
+      warning_message = "DEPRECATION WARNING: use_hyphen is deprecated and will be removed from fast_jsonapi 2.0 use (set_key_transform :dash) instead\n"
+      expect { subject }.to output(warning_message).to_stderr
+      expect(MovieSerializer.instance_variable_get(:@transform_method)).to eq :dasherize
+    end
+  end
 end

--- a/spec/shared/examples/object_serializer_class_methods_examples.rb
+++ b/spec/shared/examples/object_serializer_class_methods_examples.rb
@@ -1,0 +1,9 @@
+RSpec.shared_examples 'returning correct relationship hash' do |serializer, id_method_name, record_type|
+  it 'returns correct relationship hash' do
+    expect(relationship).to be_instance_of(Hash)
+    expect(relationship.keys).to all(be_instance_of(Symbol))
+    expect(relationship[:serializer]).to be serializer
+    expect(relationship[:id_method_name]).to be id_method_name
+    expect(relationship[:record_type]).to be record_type
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ require 'jsonapi/serializable'
 require 'jsonapi-serializers'
 
 Dir[File.dirname(__FILE__) + '/shared/contexts/*.rb'].each {|file| require file }
+Dir[File.dirname(__FILE__) + '/shared/examples/*.rb'].each {|file| require file }
 
 RSpec.configure do |config|
   config.include RSpec::Benchmark::Matchers


### PR DESCRIPTION
I refactored `object_serializer_class_methods_spec.rb` with `subject`, `let` and `shared_example` since some of the examples seem to be not well organized... Also, I added some missing test cases and fixed seemingly wrong examples!