### PR TITLE
Remove redundant fetch from ids_hash_from_record_and_relationship

### DIFF
--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -44,8 +44,7 @@ module FastJsonapi
           relationship[:record_type]
         ) unless polymorphic
 
-        object_method_name = relationship.fetch(:object_method_name, relationship[:name])
-        return unless associated_object = record.send(object_method_name)
+        return unless associated_object = record.send(relationship[:object_method_name])
 
         return associated_object.map do |object|
           id_hash_from_record object, polymorphic


### PR DESCRIPTION
`relationship.fetch(:object_method_name, relationship[:name])` is redundant since the value of `object_method_name` is already set to be `name` if `object_method_name` is nil in `has_one`, `has_many`, 'belongs_to' methods by `object_method_name: options[:object_method_name] || name`.