### PR TITLE
Remove redundant fetch from ids_hash_from_record_and_relationship

### DIFF
--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -44,8 +44,7 @@ module FastJsonapi
           relationship[:record_type]
         ) unless polymorphic
 
-        object_method_name = relationship.fetch(:object_method_name, relationship[:name])
-        return unless associated_object = record.send(object_method_name)
+        return unless associated_object = record.send(relationship[:object_method_name])
 
         return associated_object.map do |object|
           id_hash_from_record object, polymorphic

--- a/spec/lib/serialization_core_spec.rb
+++ b/spec/lib/serialization_core_spec.rb
@@ -18,7 +18,7 @@ describe FastJsonapi::ObjectSerializer do
     end
 
     it 'returns the correct hash when ids_hash_from_record_and_relationship is called for a polymorphic association' do
-      relationship = { name: :groupees, relationship_type: :has_many, polymorphic: {} }
+      relationship = { name: :groupees, relationship_type: :has_many, object_method_name: :groupees, polymorphic: {} }
       results = GroupSerializer.send :ids_hash_from_record_and_relationship, group, relationship
       expect(results).to include({ id: "1", type: :person }, { id: "2", type: :group })
     end


### PR DESCRIPTION
`relationship.fetch(:object_method_name, relationship[:name])` is redundant since the value of `object_method_name` is already set to be `name` if `object_method_name` is nil in `has_one`, `has_many`, 'belongs_to' methods by `object_method_name: options[:object_method_name] || name`.