### PR TITLE
Use lower case letter for creating serializer command

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $ bundle install
 You can use the bundled generator if you are using the library inside of
 a Rails project:
 
-    rails g Serializer Movie name year
+    rails g serializer Movie name year
 
 This will create a new serializer in `app/serializers/movie_serializer.rb`
 


### PR DESCRIPTION
When I use ```bundle exec rails g Serializer User name age``` command, it exposes the error message like:

```Could not find generator 'Serializer'. Maybe you meant 'serializer', 'mailer' or 'helper'```

So, this PR is updating documentation to use lower case letter like ```bundle exec rails g serializer User name age``` for creating serializer.