### PR TITLE
Update example generator command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $ bundle install
 You can use the bundled generator if you are using the library inside of
 a Rails project:
 
-    rails g Serializer Movie name year
+    rails g serializer Movie name year
 
 This will create a new serializer in `app/serializers/movie_serializer.rb`
 


### PR DESCRIPTION
I tried to run the example command in the readme: 

```bash
$ rails g Serializer Trip title
Could not find generator 'Serializer'. Maybe you meant 'serializer', 'helper' or 'mailer'
Run `rails generate --help` for more options.
```

Running `rails g serializer Trip title` worked just fine.