### PR TITLE
 Enable to fetch ids even when relationship_model_name_ids method is not implemented 

### DIFF
--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -168,13 +168,16 @@ module FastJsonapi
       def has_many(relationship_name, options = {})
         name = relationship_name.to_sym
         singular_name = relationship_name.to_s.singularize
+        id_from_origin = options[:id_from_origin] || false
+        default_id_method_name = id_from_origin ? :id : (singular_name + '_ids').to_sym
         serializer_key = options[:serializer] || singular_name.to_sym
         key = options[:key] || run_key_transform(relationship_name)
         record_type = options[:record_type] || run_key_transform(singular_name)
         relationship = {
           key: key,
           name: name,
-          id_method_name: options[:id_method_name] || (singular_name + '_ids').to_sym,
+          id_from_origin: id_from_origin,
+          id_method_name: options[:id_method_name] || default_id_method_name,
           record_type: record_type,
           object_method_name: options[:object_method_name] || name,
           serializer: compute_serializer_name(serializer_key),
@@ -188,12 +191,15 @@ module FastJsonapi
       def belongs_to(relationship_name, options = {})
         name = relationship_name.to_sym
         serializer_key = options[:serializer] || relationship_name.to_sym
+        id_from_origin = options[:id_from_origin] || false
+        default_id_method_name = id_from_origin ? :id : (relationship_name.to_s + '_id').to_sym
         key = options[:key] || run_key_transform(relationship_name)
         record_type = options[:record_type] || run_key_transform(relationship_name)
         add_relationship(name, {
           key: key,
           name: name,
-          id_method_name: options[:id_method_name] || (relationship_name.to_s + '_id').to_sym,
+          id_from_origin: id_from_origin,
+          id_method_name: options[:id_method_name] || default_id_method_name,
           record_type: record_type,
           object_method_name: options[:object_method_name] || name,
           serializer: compute_serializer_name(serializer_key),
@@ -206,12 +212,15 @@ module FastJsonapi
       def has_one(relationship_name, options = {})
         name = relationship_name.to_sym
         serializer_key = options[:serializer] || name
+        id_from_origin = options[:id_from_origin] || false
+        default_id_method_name = id_from_origin ? :id : (relationship_name.to_s + '_id').to_sym
         key = options[:key] || run_key_transform(relationship_name)
         record_type = options[:record_type] || run_key_transform(relationship_name)
         add_relationship(name, {
           key: key,
           name: name,
-          id_method_name: options[:id_method_name] || (relationship_name.to_s + '_id').to_sym,
+          id_from_origin: id_from_origin,
+          id_method_name: options[:id_method_name] || default_id_method_name,
           record_type: record_type,
           object_method_name: options[:object_method_name] || name,
           serializer: compute_serializer_name(serializer_key),

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -42,7 +42,7 @@ module FastJsonapi
         polymorphic = relationship[:polymorphic]
 
         return ids_hash(
-          record.public_send(relationship[:id_method_name]),
+          fetch_ids(record, relationship[:id_method_name], relationship[:object_method_name]),
           relationship[:record_type]
         ) unless polymorphic
 
@@ -53,6 +53,13 @@ module FastJsonapi
         end if associated_object.respond_to? :map
 
         id_hash_from_record associated_object, polymorphic
+      end
+
+      def fetch_ids(record, id_method_name, object_method_name)
+        record.public_send(id_method_name)
+
+      rescue NoMethodError
+        record.public_send(object_method_name).map(&:id)
       end
 
       def attributes_hash(record)

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -42,7 +42,7 @@ module FastJsonapi
         polymorphic = relationship[:polymorphic]
 
         return ids_hash(
-          fetch_ids(record, relationship[:id_method_name], relationship[:object_method_name]),
+          fetch_ids(record, relationship),
           relationship[:record_type]
         ) unless polymorphic
 
@@ -55,11 +55,12 @@ module FastJsonapi
         id_hash_from_record associated_object, polymorphic
       end
 
-      def fetch_ids(record, id_method_name, object_method_name)
-        record.public_send(id_method_name)
-
-      rescue NoMethodError
-        record.public_send(object_method_name).map(&:id)
+      def fetch_ids(record, relationship)
+        if relationship[:id_from_origin]
+          record.public_send(relationship[:object_method_name]).map{ |o| o.public_send(relationship[:id_method_name]) }
+        else
+          record.public_send(relationship[:id_method_name])
+        end
       end
 
       def attributes_hash(record)

--- a/spec/lib/serialization_core_spec.rb
+++ b/spec/lib/serialization_core_spec.rb
@@ -23,6 +23,13 @@ describe FastJsonapi::ObjectSerializer do
       expect(results).to include({ id: "1", type: :person }, { id: "2", type: :group })
     end
 
+    it 'returns the correct hash when ids_hash_from_record_and_relationship is called with unknown id_method_name' do
+      relationship = { name: :actors, relationship_type: :has_many, id_method_name: :unknown_ids_method, object_method_name: :actors }
+      results = MovieSerializer.ids_hash_from_record_and_relationship(movie, relationship)
+      expect(results.size).to eq 3
+      expect(results).to include({ id: '1', type: nil }, { id: '2', type: nil }, { id: '3', type: nil })
+    end
+
     it 'returns correct hash when ids_hash is called' do
       inputs = [{ids: %w(1 2 3), record_type: :movie}, {ids: %w(x y z), record_type: 'person'}]
       inputs.each do |hash|

--- a/spec/lib/serialization_core_spec.rb
+++ b/spec/lib/serialization_core_spec.rb
@@ -23,13 +23,6 @@ describe FastJsonapi::ObjectSerializer do
       expect(results).to include({ id: "1", type: :person }, { id: "2", type: :group })
     end
 
-    it 'returns the correct hash when ids_hash_from_record_and_relationship is called with unknown id_method_name' do
-      relationship = { name: :actors, relationship_type: :has_many, id_method_name: :unknown_ids_method, object_method_name: :actors }
-      results = MovieSerializer.ids_hash_from_record_and_relationship(movie, relationship)
-      expect(results.size).to eq 3
-      expect(results).to include({ id: '1', type: nil }, { id: '2', type: nil }, { id: '3', type: nil })
-    end
-
     it 'returns correct hash when ids_hash is called' do
       inputs = [{ids: %w(1 2 3), record_type: :movie}, {ids: %w(x y z), record_type: 'person'}]
       inputs.each do |hash|


### PR DESCRIPTION
This PR relates to https://github.com/Netflix/fast_jsonapi/issues/104.
I enabled fetch ids even when `id_method_name` is not implemented on the record. When the record raises `NoMethodError` by calling `id_method_name`, it tries to fetch ids via calling `record.public_send(object_method_name).map(&:id)`. 