### PR TITLE
add object serializer inheritance of attributes, fixes #79

### DIFF
--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -91,6 +91,12 @@ module FastJsonapi
     end
 
     class_methods do
+
+      def inherited(subclass)
+        super(subclass)
+        attributes_to_serialize.each { |name, method_or_block| subclass.attribute(name, method_or_block) }
+      end
+
       def reflected_record_type
         return @reflected_record_type if defined?(@reflected_record_type)
 

--- a/spec/lib/object_serializer_inheritance_spec.rb
+++ b/spec/lib/object_serializer_inheritance_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe FastJsonapi::ObjectSerializer do
+  include_context 'movie class'
+
+  let(:subclass_serializer) do
+    Class.new(MovieSerializer) do
+      attributes :director
+    end
+  end
+
+  context 'when testing subclass of object serializer' do
+
+    it 'includes parent attributes' do
+      MovieSerializer.attributes_to_serialize.each do |k,v|
+        expect(subclass_serializer.attributes_to_serialize[k]).to eq(v)
+      end
+    end
+
+    it 'includes child attributes' do
+      expect(subclass_serializer.attributes_to_serialize[:director]).to eq(:director)
+    end
+
+    it 'doesnt change parent class attributes' do
+      subclass_serializer
+      expect(MovieSerializer.attributes_to_serialize).not_to have_key(:director)
+    end
+  end
+end


### PR DESCRIPTION
This is to address issue #79.

Noteworthy is that this only addresses attribute inheritance (what is mentioned in that issue). It does not attempt to expand scope to relationship inheritance, etc. I'll have to leave that to someone else who has additional time.