### PR TITLE
Enable to set race_condition_ttl for cache_options

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Option | Purpose | Example
 ------------ | ------------- | -------------
 set_type | Type name of Object | ```set_type :movie ```
 set_id | ID of Object | ```set_id :owner_id ```
-cache_options | Hash to enable caching and set cache length | ```cache_options enabled: true, cache_length: 12.hours```
+cache_options | Hash to enable caching and set cache length | ```cache_options enabled: true, cache_length: 12.hours, race_condition_ttl: 10.seconds```
 id_method_name | Set custom method name to get ID of an object | ```has_many :locations, id_method_name: :place_ids ```
 object_method_name | Set custom method name to get related objects | ```has_many :locations, object_method_name: :places ```
 record_type | Set custom Object Type for a relationship | ```belongs_to :owner, record_type: :user```

--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -138,6 +138,7 @@ module FastJsonapi
       def cache_options(cache_options)
         self.cached = cache_options[:enabled] || false
         self.cache_length = cache_options[:cache_length] || 5.minutes
+        self.race_condition_ttl = cache_options[:race_condition_ttl] || 5.seconds
       end
 
       def attributes(*attributes_list, &block)

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -19,6 +19,7 @@ module FastJsonapi
                       :record_type,
                       :record_id,
                       :cache_length,
+                      :race_condition_ttl,
                       :cached
       end
     end
@@ -76,7 +77,7 @@ module FastJsonapi
 
       def record_hash(record)
         if cached
-          record_hash = Rails.cache.fetch(record.cache_key, expires_in: cache_length) do
+          record_hash = Rails.cache.fetch(record.cache_key, expires_in: cache_length, race_condition_ttl: race_condition_ttl) do
             temp_hash = id_hash(id_from_record(record), record_type) || { id: nil, type: record_type }
             temp_hash[:attributes] = attributes_hash(record) if attributes_to_serialize.present?
             temp_hash[:relationships] = {}


### PR DESCRIPTION
This PR relates to https://github.com/Netflix/fast_jsonapi/issues/21 !
As [Rails Guide](http://guides.rubyonrails.org/caching_with_rails.html) says, it is a best practice to set `expires_in` with `race_condition_ttl` option. So I created `race_condition_ttl` and its default value is 5 seconds. Thank you! 👍 