### PR TITLE
Fix serialization command in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $ bundle install
 You can use the bundled generator if you are using the library inside of
 a Rails project:
 
-    rails g Serializer Movie name year
+    rails g serializer Movie name year
 
 This will create a new serializer in `app/serializers/movie_serializer.rb`
 


### PR DESCRIPTION
Rails generator names are case sensitive. In the README it was says `Serializer` but it should be `serializer`.