### PR TITLE
Update README for rails command line usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $ bundle install
 You can use the bundled generator if you are using the library inside of
 a Rails project:
 
-    rails g Serializer Movie name year
+    rails g serializer Movie name year
 
 This will create a new serializer in `app/serializers/movie_serializer.rb`
 


### PR DESCRIPTION
Switching to this on a Rails 5.1.6 app and was copying the command from README to see it work and ran into this.

``` shell
➜ rails g Serializer Movie name year
Could not find generator 'Serializer'. Maybe you meant 'serializer', 'erb:mailer' or 'mailer'

➜ rails g serializer Movie name year
    create  app/serializers/movie_serializer.rb

➜ cat app/serializers/movie_serializer.rb
class MovieSerializer
  include FastJsonapi::ObjectSerializer
  attributes :name, :year
end
```

