### PR TITLE
Make to_json twice as fast as it used to be

### DIFF
--- a/spec/lib/multi_to_json_spec.rb
+++ b/spec/lib/multi_to_json_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe FastJsonapi::MultiToJson do
+  include_context 'movie class'
+
+  describe 'self.to_json' do
+    subject { FastJsonapi::MultiToJson.to_json movie }
+
+    it { is_expected.to eq("{\"id\":232,\"name\":\"test movie\",\"actor_ids\":[1,2,3],\"owner_id\":3,\"movie_type_id\":1}") }
+  end
+end


### PR DESCRIPTION
I found the current implementation of `to_json` can be slow since it defines `to_json` method dynamically first time the method is called. So I use `class_eval` instead and change to define the method when class itself is evaluated. As a result `to_json` method bacame two times faster (from `0.4819999448955059` ms to `0.2079999540001154` ms) and the class became much simpler!

Below is the test code I used to check the performance.

```
require 'spec_helper'

describe FastJsonapi::MultiToJson do
  include_context 'movie class'

  before(:all) { GC.disable }
  after(:all) { GC.enable }

  describe 'self.to_json' do
    it do
      second = Benchmark.measure { FastJsonapi::MultiToJson.to_json movie }.real * 1000
      print 'to_json: '
      puts "#{second} ms"
    end
  end
end
```