### PR TITLE
Version file to manage version & removing date gemspec dependency

### DIFF
--- a/fast_jsonapi.gemspec
+++ b/fast_jsonapi.gemspec
@@ -1,12 +1,16 @@
+lib = File.expand_path('lib', __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+require "fast_jsonapi/version"
+
 Gem::Specification.new do |gem|
   gem.name = "fast_jsonapi"
-  gem.version = "1.1.1"
+  gem.version = FastJsonapi::VERSION
 
   gem.required_rubygems_version = Gem::Requirement.new(">= 0") if gem.respond_to? :required_rubygems_version=
   gem.metadata = { "allowed_push_host" => "https://rubygems.org" } if gem.respond_to? :metadata=
   gem.require_paths = ["lib"]
   gem.authors = ["Shishir Kakaraddi", "Srinivas Raghunathan", "Adam Gross"]
-  gem.date = "2018-02-01"
   gem.description = "JSON API(jsonapi.org) serializer that works with rails and can be used to serialize any kind of ruby objects"
   gem.email = ""
   gem.extra_rdoc_files = [

--- a/lib/fast_jsonapi/version.rb
+++ b/lib/fast_jsonapi/version.rb
@@ -1,0 +1,3 @@
+module FastJsonapi
+  VERSION = "1.1.1"
+end


### PR DESCRIPTION
### Description

- [x]   Added version file to manage versions
- [x]  Removing date dependency from Gemspec [as it defaults to UTC](https://ruby-doc.org/stdlib-2.2.3/libdoc/rubygems/rdoc/Gem/Specification.html#method-i-date). Fixes #136 