### PR TITLE
Enable to use block to define relationship

### DIFF
--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -166,21 +166,21 @@ module FastJsonapi
         self.relationships_to_serialize[name] = relationship
      end
 
-      def has_many(relationship_name, options = {})
+      def has_many(relationship_name, options = {}, &block)
         name = relationship_name.to_sym
-        hash = create_relationship_hash(relationship_name, :has_many, options)
+        hash = create_relationship_hash(relationship_name, :has_many, options, block)
         add_relationship(name, hash)
       end
 
-      def has_one(relationship_name, options = {})
+      def has_one(relationship_name, options = {}, &block)
         name = relationship_name.to_sym
-        hash = create_relationship_hash(relationship_name, :has_one, options)
+        hash = create_relationship_hash(relationship_name, :has_one, options, block)
         add_relationship(name, hash)
       end
 
       alias belongs_to has_one
 
-      def create_relationship_hash(base_key, relationship_type, options)
+      def create_relationship_hash(base_key, relationship_type, options, block)
         name = base_key.to_sym
         if relationship_type == :has_many
           base_serialization_key = base_key.to_s.singularize
@@ -197,6 +197,7 @@ module FastJsonapi
           id_method_name: options[:id_method_name] || "#{base_serialization_key}#{id_postfix}".to_sym,
           record_type: options[:record_type] || run_key_transform(base_key_sym),
           object_method_name: options[:object_method_name] || name,
+          object_block: block,
           serializer: compute_serializer_name(options[:serializer] || base_key_sym),
           relationship_type: relationship_type,
           cached: options[:cached] || false,


### PR DESCRIPTION
This PR relates to https://github.com/Netflix/fast_jsonapi/issues/165.

I enabled to use block to define relationships. For example, if `An actor belongs to an agency, and an agency belongs to a city`, you can refer to the city directly from `ActorSerializer` like below.

```
class ActorSerializer
  include FastJsonapi::ObjectSerializer
  attributes :name, :email

  belongs_to :city do |actor|
    actor.agency.city
  end
end
```

Thank you! 👍 
