### PR TITLE
Require logger to avoid exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ test.db
 
 # For those who install gems locally to a vendor dir
 /vendor
+
+# Don't checkin Gemfile.lock 
+# See: http://yehudakatz.com/2010/12/16/clarifying-the-roles-of-the-gemspec-and-gemfile/
+Gemfile.lock

--- a/lib/fast_jsonapi/multi_to_json.rb
+++ b/lib/fast_jsonapi/multi_to_json.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'logger'
+
 # Usage:
 #   class Movie
 #     def to_json(payload)


### PR DESCRIPTION
While testing the gem i ran into an issue by calling `#serialized_json`

```
fast_jsonapi-1.1.1/lib/fast_jsonapi/multi_to_json.rb:48:in `logger': uninitialized constant FastJsonapi::MultiToJson::Logger (NameError)
  from ../fast_jsonapi-1.1.1/lib/fast_jsonapi/multi_to_json.rb:89:in `define_to_json'
  from ../fast_jsonapi-1.1.1/lib/fast_jsonapi/multi_to_json.rb:82:in `rescue in to_json'
  from ../fast_jsonapi-1.1.1/lib/fast_jsonapi/multi_to_json.rb:80:in `to_json'
  from ../fast_jsonapi-1.1.1/lib/fast_jsonapi/serialization_core.rb:98:in `to_json'
  from ../fast_jsonapi-1.1.1/lib/fast_jsonapi/object_serializer.rb:62:in `serialized_json'
```