### PR TITLE
Add ruby version requirement '>= 2.0.0'

### DIFF
--- a/fast_jsonapi.gemspec
+++ b/fast_jsonapi.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |gem|
   gem.name = "fast_jsonapi"
   gem.version = FastJsonapi::VERSION
 
+  gem.required_ruby_version = '>= 2.0.0' if gem.respond_to? :required_ruby_version=
   gem.required_rubygems_version = Gem::Requirement.new(">= 0") if gem.respond_to? :required_rubygems_version=
   gem.metadata = { "allowed_push_host" => "https://rubygems.org" } if gem.respond_to? :metadata=
   gem.require_paths = ["lib"]


### PR DESCRIPTION
With ruby 1.9.3 #serialized_json raises an exception:
```
NameError:
       undefined local variable or method `caller_locations' for FastJsonapi::MultiToJson:Module
```
`Kernel#caller_locations` was added in ruby '2.0.0'
Source: https://docs.ruby-lang.org/en/2.2.0/NEWS-2_0_0.html