### PR TITLE
Remove duplicate id_hash call from #record_hash

### DIFF
--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -86,7 +86,6 @@ module FastJsonapi
       def record_hash(record, params = {})
         if cached
           record_hash = Rails.cache.fetch(record.cache_key, expires_in: cache_length, race_condition_ttl: race_condition_ttl) do
-            temp_hash = id_hash(id_from_record(record), record_type) || { id: nil, type: record_type }
             temp_hash = id_hash(id_from_record(record), record_type, true)
             temp_hash[:attributes] = attributes_hash(record, params) if attributes_to_serialize.present?
             temp_hash[:relationships] = {}


### PR DESCRIPTION
A duplicate call to #id_hash seems to have got in during rebase from https://github.com/Netflix/fast_jsonapi/pull/153/files#diff-0d22ea72f1e72c75e7887cdbcba46871R89