### PR TITLE
Use string for serializer name

### DIFF
--- a/spec/lib/object_serializer_class_methods_spec.rb
+++ b/spec/lib/object_serializer_class_methods_spec.rb
@@ -181,7 +181,7 @@ describe FastJsonapi::ObjectSerializer do
           attributes :name, :release_year
           has_many :actors
           belongs_to :owner, record_type: :user
-          belongs_to :movie_type, serializer: "#{key_transform}_movie_type"
+          belongs_to :movie_type, serializer: "#{key_transform}_movie_type".to_sym
         end
         movie_type_serializer_class = Object.const_set(movie_type_serializer_name, Class.new)
         movie_type_serializer_class.instance_eval do


### PR DESCRIPTION
This PR fixes the a spec broken by https://github.com/Netflix/fast_jsonapi/pull/198.