### PR TITLE
Feature/add params to relationship block

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ By default, attributes are read directly from the model property of the same nam
 ```ruby
 class MovieSerializer
   include FastJsonapi::ObjectSerializer
-  
+
   attribute :name
 end
 ```
@@ -184,9 +184,9 @@ Custom attributes that must be serialized but do not exist on the model can be d
 ```ruby
 class MovieSerializer
   include FastJsonapi::ObjectSerializer
-  
+
   attributes :name, :year
-  
+
   attribute :name_with_year do |object|
     "#{object.name} (#{object.year})"
   end
@@ -198,7 +198,7 @@ The block syntax can also be used to override the property on the object:
 ```ruby
 class MovieSerializer
   include FastJsonapi::ObjectSerializer
-  
+
   attribute :name do |object|
     "#{object.name} Part 2"
   end
@@ -254,7 +254,7 @@ related to a current authenticated user. The `options[:params]` value covers the
 cases by allowing you to pass in a hash of additional parameters necessary for
 your use case.
 
-Leveraging the new params is easy, when you define a custom attribute with a
+Leveraging the new params is easy, when you define a custom attribute or relationship with a
 block you opt-in to using params by adding it as a block parameter.
 
 ```ruby
@@ -267,6 +267,11 @@ class MovieSerializer
     # in here, params is a hash containing the `:current_user` key
     params[:current_user].is_employee? ? true : false
   end
+
+  belongs_to :primary_agent do |movie, params|
+    # in here, params is a hash containing the `:current_user` key
+    params[:current_user].is_employee? ? true : false
+  end
 end
 
 # ...
@@ -275,7 +280,7 @@ serializer = MovieSerializer.new(movie, {params: {current_user: current_user}})
 serializer.serializable_hash
 ```
 
-Custom attributes that only receive the resource are still possible by defining
+Custom attributes and relationships that only receive the resource are still possible by defining
 the block to only receive one argument.
 
 ### Customizable Options

--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -39,7 +39,7 @@ module FastJsonapi
       return serializable_hash unless @resource
 
       serializable_hash[:data] = self.class.record_hash(@resource, @params)
-      serializable_hash[:included] = self.class.get_included_records(@resource, @includes, @known_included_objects) if @includes.present?
+      serializable_hash[:included] = self.class.get_included_records(@resource, @includes, @known_included_objects, @params) if @includes.present?
       serializable_hash
     end
 
@@ -50,7 +50,7 @@ module FastJsonapi
       included = []
       @resource.each do |record|
         data << self.class.record_hash(record, @params)
-        included.concat self.class.get_included_records(record, @includes, @known_included_objects) if @includes.present?
+        included.concat self.class.get_included_records(record, @includes, @known_included_objects, @params) if @includes.present?
       end
 
       serializable_hash[:data] = data

--- a/spec/lib/object_serializer_attribute_param_spec.rb
+++ b/spec/lib/object_serializer_attribute_param_spec.rb
@@ -23,7 +23,7 @@ describe FastJsonapi::ObjectSerializer do
         end
       end
 
-      class User < Struct.new(:viewed); end
+      User = Struct.new(:viewed)
     end
 
     after(:context) do

--- a/spec/lib/object_serializer_relationship_param_spec.rb
+++ b/spec/lib/object_serializer_relationship_param_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+describe FastJsonapi::ObjectSerializer do
+  include_context 'movie class'
+
+  context "params option" do
+    let(:hash) { serializer.serializable_hash }
+
+    before(:context) do
+      class MovieSerializer
+        has_many :agencies do |movie, params|
+          movie.actors.map(&:agency) if params[:authorized]
+        end
+
+        belongs_to :primary_agency do |movie, params|
+          movie.actors.map(&:agency)[0] if params[:authorized]
+        end
+
+        belongs_to :secondary_agency do |movie|
+          movie.actors.map(&:agency)[1]
+        end
+      end
+    end
+
+    context "passing params to the serializer" do
+      let(:params) { {authorized: true} }
+      let(:options_with_params) { {params: params} }
+
+      context "with a single record" do
+        let(:serializer) { MovieSerializer.new(movie, options_with_params) }
+
+        it "handles relationships that use params" do
+          ids = hash[:data][:relationships][:agencies][:data].map{|a| a[:id]}
+          ids.map!(&:to_i)
+          expect(ids).to eq [0,1,2]
+        end
+
+        it "handles relationships that don't use params" do
+          expect(hash[:data][:relationships][:secondary_agency][:data]).to include({id: 1.to_s})
+        end
+      end
+
+      context "with a list of records" do
+        let(:movies) { build_movies(3) }
+        let(:params) { {authorized: true} }
+        let(:serializer) { MovieSerializer.new(movies, options_with_params) }
+
+        it "handles relationship params when passing params to a list of resources" do
+          relationships_hashes = hash[:data].map{|a| a[:relationships][:agencies][:data]}.uniq.flatten
+          expect(relationships_hashes.map{|a| a[:id].to_i}).to contain_exactly 0,1,2
+
+          uniq_count = hash[:data].map{|a| a[:relationships][:primary_agency] }.uniq.count
+          expect(uniq_count).to eq 1
+        end
+
+        it "handles relationships without params" do
+          uniq_count = hash[:data].map{|a| a[:relationships][:secondary_agency] }.uniq.count
+          expect(uniq_count).to eq 1
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds the ability to send params to a `:belongs_to, :has_many, :has_one` custom relationship

```ruby
class MovieSerializer
  class MovieSerializer
  include FastJsonapi::ObjectSerializer

  attributes :name, :year
  attribute :can_view_early do |movie, params|
    # in here, params is a hash containing the `:current_user` key
    params[:current_user].is_employee? ? true : false
  end

  belongs_to :primary_agent do |movie, params|
    # in here, params is a hash containing the `:current_user` key
    params[:current_user].is_employee? ? true : false
  end
end
```