### PR TITLE
Always return a symbol from compute_serializer_name.

### DIFF
--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -221,7 +221,7 @@ module FastJsonapi
       end
 
       def compute_serializer_name(serializer_key)
-        return serializer_key unless serializer_key.is_a? Symbol
+        return serializer_key.to_s.to_sym unless serializer_key.is_a? Symbol
         namespace = self.name.gsub(/()?\w+Serializer$/, '')
         serializer_name = serializer_key.to_s.classify + 'Serializer'
         return (namespace + serializer_name).to_sym if namespace.present?

--- a/spec/lib/object_serializer_class_methods_spec.rb
+++ b/spec/lib/object_serializer_class_methods_spec.rb
@@ -251,7 +251,7 @@ describe FastJsonapi::ObjectSerializer do
           attributes :name, :release_year
           has_many :actors
           belongs_to :owner, record_type: :user
-          belongs_to :movie_type, serializer: "#{key_transform}_movie_type".to_sym
+          belongs_to :movie_type, serializer: "#{key_transform}_movie_type"
         end
         movie_type_serializer_class = Object.const_set(movie_type_serializer_name, Class.new)
         movie_type_serializer_class.instance_eval do


### PR DESCRIPTION
I made a previous change that if you passed a class instead of a symbol, it would just return it (https://github.com/Netflix/fast_jsonapi/pull/198). This method works either way but it makes more sense to be uniform about what we return (always a symbol class). It also allows for us to clean up a test also.

### Related PRs:
#198
#201

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netflix/fast_jsonapi/206)
<!-- Reviewable:end -->
