### PR TITLE
Remove extra 'class MovieSerializer' from an example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,6 @@ block you opt-in to using params by adding it as a block parameter.
 
 ```ruby
 class MovieSerializer
-  class MovieSerializer
   include FastJsonapi::ObjectSerializer
 
   attributes :name, :year


### PR DESCRIPTION
This PR is to fix a minor typo in the README.  There is a duplicate `class MovieSerializer` [in the example for `Params`](https://github.com/Netflix/fast_jsonapi#params).