### PR TITLE
Fix serialization for nested nil includes with block

### DIFF
--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -182,7 +182,7 @@ module FastJsonapi
           object = relationship[:object_block].call(record, params)
 
           return object.map(&:id) if object.respond_to? :map
-          return object.id
+          return object.try(:id)
         end
 
         record.public_send(relationship[:id_method_name])

--- a/spec/lib/object_serializer_spec.rb
+++ b/spec/lib/object_serializer_spec.rb
@@ -97,6 +97,13 @@ describe FastJsonapi::ObjectSerializer do
       expect(serializable_hash['data']['relationships']['owner']['data']).to be nil
     end
 
+    it 'returns correct json when belongs_to returns nil and there is a block for the relationship' do
+      movie.owner_id = nil
+      json = MovieSerializer.new(movie, {include: [:owner]}).serialized_json
+      serializable_hash = JSON.parse(json)
+      expect(serializable_hash['data']['relationships']['owner']['data']).to be nil
+    end
+
     it 'returns correct json when has_one returns nil' do
       supplier.account_id = nil
       json = SupplierSerializer.new(supplier).serialized_json

--- a/spec/shared/contexts/movie_context.rb
+++ b/spec/shared/contexts/movie_context.rb
@@ -43,6 +43,13 @@ RSpec.shared_context 'movie class' do
         ac
       end
 
+      def owner
+        return unless owner_id
+        ow = Owner.new
+        ow.id = owner_id
+        ow
+      end
+
       def cache_key
         "#{id}"
       end
@@ -146,6 +153,14 @@ RSpec.shared_context 'movie class' do
       attr_accessor :id
     end
 
+    class Owner
+      attr_accessor :id
+    end
+
+    class OwnerSerializer
+      include FastJsonapi::ObjectSerializer
+    end
+
     # serializers
     class MovieSerializer
       include FastJsonapi::ObjectSerializer
@@ -153,7 +168,9 @@ RSpec.shared_context 'movie class' do
       # director attr is not mentioned intentionally
       attributes :name, :release_year
       has_many :actors
-      belongs_to :owner, record_type: :user
+      belongs_to :owner, record_type: :user do |object, params|
+        object.owner
+      end
       belongs_to :movie_type
       has_one :advertising_campaign
     end


### PR DESCRIPTION
Optional belongs_to association throws `NoMethodError: undefined method 'id' for nil:NilClass`

```
class Foo < ApplicationRecord
  belongs_to :bar, optional: true
end
```
```
class FooSerializer
  include FastJsonapi::ObjectSerializer
 
  belongs_to :bar do |object, params|
    params[:authorized] ? object.bar : nil
  end
end
```