### PR TITLE
Use a Railtie to extend Rails

### DIFF
--- a/lib/extensions/has_one.rb
+++ b/lib/extensions/has_one.rb
@@ -1,20 +1,18 @@
 # frozen_string_literal: true
 
-if defined?(::ActiveRecord)
-  ::ActiveRecord::Associations::Builder::HasOne.class_eval do
-    # Based on
-    # https://github.com/rails/rails/blob/master/activerecord/lib/active_record/associations/builder/collection_association.rb#L50
-    # https://github.com/rails/rails/blob/master/activerecord/lib/active_record/associations/builder/singular_association.rb#L11
-    def self.define_accessors(mixin, reflection)
-      super
-      name = reflection.name
-      mixin.class_eval <<-CODE, __FILE__, __LINE__ + 1
-        def #{name}_id
-          # if an attribute is already defined with this methods name we should just use it
-          return read_attribute(__method__) if has_attribute?(__method__)
-          association(:#{name}).reader.try(:id)
-        end
-      CODE
-    end
+::ActiveRecord::Associations::Builder::HasOne.class_eval do
+  # Based on
+  # https://github.com/rails/rails/blob/master/activerecord/lib/active_record/associations/builder/collection_association.rb#L50
+  # https://github.com/rails/rails/blob/master/activerecord/lib/active_record/associations/builder/singular_association.rb#L11
+  def self.define_accessors(mixin, reflection)
+    super
+    name = reflection.name
+    mixin.class_eval <<-CODE, __FILE__, __LINE__ + 1
+      def #{name}_id
+        # if an attribute is already defined with this methods name we should just use it
+        return read_attribute(__method__) if has_attribute?(__method__)
+        association(:#{name}).reader.try(:id)
+      end
+    CODE
   end
 end

--- a/lib/fast_jsonapi.rb
+++ b/lib/fast_jsonapi.rb
@@ -2,5 +2,9 @@
 
 module FastJsonapi
   require 'fast_jsonapi/object_serializer'
-  require 'extensions/has_one'
+  if defined?(::Rails)
+    require 'fast_jsonapi/railtie'
+  elsif defined?(::ActiveRecord)
+    require 'extensions/has_one'
+  end
 end

--- a/lib/fast_jsonapi/railtie.rb
+++ b/lib/fast_jsonapi/railtie.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails/railtie'
+
+class Railtie < Rails::Railtie
+  initializer 'fast_jsonapi.active_record' do
+    ActiveSupport.on_load :active_record do
+      require 'extensions/has_one'
+    end
+  end
+end


### PR DESCRIPTION
Railties are the core of the Rails framework and provide several hooks to extend Rails, using Railties is the 'Rails-way' to introduce extensions/patches to Rails libraries/components.

Based on this I'm going to add hooks to introduce a new renderer for Action Controller as described in https://github.com/Netflix/fast_jsonapi/issues/175