### PR TITLE
Set type value when setting key transform

### DIFF
--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -118,6 +118,9 @@ module FastJsonapi
           underscore: :underscore
         }
         self.transform_method = mapping[transform_name.to_sym]
+
+        # ensure that the record type is correctly transformed
+        set_type(reflected_record_type) if reflected_record_type
       end
 
       def run_key_transform(input)
@@ -170,7 +173,7 @@ module FastJsonapi
           self.cachable_relationships_to_serialize[name] = relationship
         end
         self.relationships_to_serialize[name] = relationship
-     end
+      end
 
       def has_many(relationship_name, options = {}, &block)
         name = relationship_name.to_sym

--- a/spec/lib/object_serializer_class_methods_spec.rb
+++ b/spec/lib/object_serializer_class_methods_spec.rb
@@ -312,7 +312,6 @@ describe FastJsonapi::ObjectSerializer do
         movie_type_serializer_class.instance_eval do
           include FastJsonapi::ObjectSerializer
           set_key_transform key_transform
-          set_type :movie_type
           attributes :name
         end
       end
@@ -321,25 +320,25 @@ describe FastJsonapi::ObjectSerializer do
     context 'when key_transform is dash' do
       let(:key_transform) { :dash }
 
-      it_behaves_like 'returning key transformed hash', :'movie-type', :'release-year'
+      it_behaves_like 'returning key transformed hash', :'movie-type', :'dash-movie-type', :'release-year'
     end
 
     context 'when key_transform is camel' do
       let(:key_transform) { :camel }
 
-      it_behaves_like 'returning key transformed hash', :MovieType, :ReleaseYear
+      it_behaves_like 'returning key transformed hash', :MovieType, :CamelMovieType, :ReleaseYear
     end
 
     context 'when key_transform is camel_lower' do
       let(:key_transform) { :camel_lower }
 
-      it_behaves_like 'returning key transformed hash', :movieType, :releaseYear
+      it_behaves_like 'returning key transformed hash', :movieType, :camelLowerMovieType, :releaseYear
     end
 
     context 'when key_transform is underscore' do
       let(:key_transform) { :underscore }
 
-      it_behaves_like 'returning key transformed hash', :movie_type, :release_year
+      it_behaves_like 'returning key transformed hash', :movie_type, :underscore_movie_type, :release_year
     end
   end
 end

--- a/spec/shared/examples/object_serializer_class_methods_examples.rb
+++ b/spec/shared/examples/object_serializer_class_methods_examples.rb
@@ -8,11 +8,11 @@ RSpec.shared_examples 'returning correct relationship hash' do |serializer, id_m
   end
 end
 
-RSpec.shared_examples 'returning key transformed hash' do |movie_type, release_year|
+RSpec.shared_examples 'returning key transformed hash' do |movie_type, serializer_type, release_year|
   it 'returns correctly transformed hash' do
     expect(hash[:data][0][:attributes]).to have_key(release_year)
     expect(hash[:data][0][:relationships]).to have_key(movie_type)
     expect(hash[:data][0][:relationships][movie_type][:data][:type]).to eq(movie_type)
-    expect(hash[:included][0][:type]).to eq(movie_type)
+    expect(hash[:included][0][:type]).to eq(serializer_type)
   end
 end


### PR DESCRIPTION
This simply adds a call to the `set_type` method from `set_key_transform`, which will ensure that the `record_type` is transformed as is expected.

This fixes #248
