### PR TITLE
Adds the option to select the serializer attributes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,16 @@ class MovieSerializer
 end
 ```
 
+### Select attributes
+
+Support for explicit attributes declaration through ` options[:attributes] `.
+
+```ruby
+options = {}
+options[:attributes] = [:name] # will only include name attribute into attributes hash
+MovieSerializer.new([movie, movie], options).serialized_json
+```
+
 ### Compound Document
 
 Support for top-level and nested included associations through ` options[:include] `.

--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -38,7 +38,7 @@ module FastJsonapi
 
       return serializable_hash unless @resource
 
-      serializable_hash[:data] = self.class.record_hash(@resource, @params)
+      serializable_hash[:data] = self.class.record_hash(@resource, @params, @attributes)
       serializable_hash[:included] = self.class.get_included_records(@resource, @includes, @known_included_objects, @params) if @includes.present?
       serializable_hash
     end
@@ -49,7 +49,7 @@ module FastJsonapi
       data = []
       included = []
       @resource.each do |record|
-        data << self.class.record_hash(record, @params)
+        data << self.class.record_hash(record, @params, @attributes)
         included.concat self.class.get_included_records(record, @includes, @known_included_objects, @params) if @includes.present?
       end
 
@@ -73,7 +73,9 @@ module FastJsonapi
       @meta = options[:meta]
       @links = options[:links]
       @params = options[:params] || {}
+      @attributes = options[:attributes] || []
       raise ArgumentError.new("`params` option passed to serializer must be a hash") unless @params.is_a?(Hash)
+      raise ArgumentError.new("`attributes` option passed to serializer must be a array") unless @attributes.is_a?(Array)
 
       if options[:include].present?
         @includes = options[:include].delete_if(&:blank?).map(&:to_sym)

--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -72,10 +72,9 @@ module FastJsonapi
       @known_included_objects = {}
       @meta = options[:meta]
       @links = options[:links]
+      @attributes = options[:attributes]
       @params = options[:params] || {}
-      @attributes = options[:attributes] || []
       raise ArgumentError.new("`params` option passed to serializer must be a hash") unless @params.is_a?(Hash)
-      raise ArgumentError.new("`attributes` option passed to serializer must be a array") unless @attributes.is_a?(Array)
 
       if options[:include].present?
         @includes = options[:include].delete_if(&:blank?).map(&:to_sym)

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -72,7 +72,7 @@ module FastJsonapi
         end
       end
 
-      def attributes_hash(record, params = {}, attributes = [])
+      def attributes_hash(record, params = {}, attributes = nil)
         attributes_to_serialize.reject! { |x| !attributes.include?(x) } if attributes
         attributes_to_serialize.each_with_object({}) do |(key, method), attr_hash|
           attr_hash[key] = if method.is_a?(Proc)
@@ -95,7 +95,7 @@ module FastJsonapi
         end
       end
 
-      def record_hash(record, params = {}, attributes = [])
+      def record_hash(record, params = {}, attributes = nil)
         if cached
           record_hash = Rails.cache.fetch(record.cache_key, expires_in: cache_length, race_condition_ttl: race_condition_ttl) do
             temp_hash = id_hash(id_from_record(record), record_type, true)

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -72,7 +72,8 @@ module FastJsonapi
         end
       end
 
-      def attributes_hash(record, params = {})
+      def attributes_hash(record, params = {}, attributes = [])
+        attributes_to_serialize.reject! { |x| !attributes.include?(x) } if attributes
         attributes_to_serialize.each_with_object({}) do |(key, method), attr_hash|
           attr_hash[key] = if method.is_a?(Proc)
             method.arity == 1 ? method.call(record) : method.call(record, params)
@@ -94,11 +95,11 @@ module FastJsonapi
         end
       end
 
-      def record_hash(record, params = {})
+      def record_hash(record, params = {}, attributes = [])
         if cached
           record_hash = Rails.cache.fetch(record.cache_key, expires_in: cache_length, race_condition_ttl: race_condition_ttl) do
             temp_hash = id_hash(id_from_record(record), record_type, true)
-            temp_hash[:attributes] = attributes_hash(record, params) if attributes_to_serialize.present?
+            temp_hash[:attributes] = attributes_hash(record, params, attributes) if attributes_to_serialize.present?
             temp_hash[:relationships] = {}
             temp_hash[:relationships] = relationships_hash(record, cachable_relationships_to_serialize, params) if cachable_relationships_to_serialize.present?
             temp_hash[:links] = links_hash(record, params) if data_links.present?
@@ -108,7 +109,7 @@ module FastJsonapi
           record_hash
         else
           record_hash = id_hash(id_from_record(record), record_type, true)
-          record_hash[:attributes] = attributes_hash(record, params) if attributes_to_serialize.present?
+          record_hash[:attributes] = attributes_hash(record, params, attributes) if attributes_to_serialize.present?
           record_hash[:relationships] = relationships_hash(record, nil, params) if relationships_to_serialize.present?
           record_hash[:links] = links_hash(record, params) if data_links.present?
           record_hash

--- a/spec/lib/instrumentation/as_notifications_negative_spec.rb
+++ b/spec/lib/instrumentation/as_notifications_negative_spec.rb
@@ -9,6 +9,7 @@ describe FastJsonapi::ObjectSerializer do
       options = {}
       options[:meta] = { total: 2 }
       options[:include] = [:actors]
+      options[:attributes] = [:name]
 
       @serializer = MovieSerializer.new([movie, movie], options)
     end
@@ -23,7 +24,7 @@ describe FastJsonapi::ObjectSerializer do
         end
 
         serialized_hash = @serializer.serializable_hash
-
+        
         expect(events.length).to eq(0)
 
         expect(serialized_hash.key?(:data)).to eq(true)

--- a/spec/lib/instrumentation/as_notifications_spec.rb
+++ b/spec/lib/instrumentation/as_notifications_spec.rb
@@ -23,6 +23,7 @@ describe FastJsonapi::ObjectSerializer do
       options = {}
       options[:meta] = { total: 2 }
       options[:include] = [:actors]
+      options[:attributes] = [:name]
 
       @serializer = MovieSerializer.new([movie, movie], options)
     end

--- a/spec/lib/object_serializer_caching_spec.rb
+++ b/spec/lib/object_serializer_caching_spec.rb
@@ -16,11 +16,12 @@ describe FastJsonapi::ObjectSerializer do
       options[:links] = { self: 'self' }
 
       options[:include] = [:actors]
+      options[:attributes] = [:name]
       serializable_hash = CachingMovieSerializer.new([movie, movie], options).serializable_hash
 
       expect(serializable_hash[:data].length).to eq 2
       expect(serializable_hash[:data][0][:relationships].length).to eq 3
-      expect(serializable_hash[:data][0][:attributes].length).to eq 2
+      expect(serializable_hash[:data][0][:attributes].length).to eq 1
 
       expect(serializable_hash[:meta]).to be_instance_of(Hash)
       expect(serializable_hash[:links]).to be_instance_of(Hash)
@@ -35,6 +36,7 @@ describe FastJsonapi::ObjectSerializer do
       expect(serializable_hash[:meta]).to be nil
       expect(serializable_hash[:links]).to be nil
       expect(serializable_hash[:included]).to be nil
+      expect(serializable_hash[:attributes]).to be nil
     end
 
     it 'uses cached values for the record' do

--- a/spec/lib/object_serializer_performance_spec.rb
+++ b/spec/lib/object_serializer_performance_spec.rb
@@ -69,7 +69,7 @@ describe FastJsonapi::ObjectSerializer, performance: true do
     puts
     puts message
 
-    name_length = SERIALIZERS.collect { |s| s[1].fetch(:name, s[0]).length }.max
+    name_length = SERIALIZERS.collect { |s| s[1].fetch(:name) {s[0]}.length }.max
 
     puts format("%-#{name_length+1}s %-10s %-10s %s", 'Serializer', 'Records', 'Time', 'Speed Up')
 
@@ -81,7 +81,7 @@ describe FastJsonapi::ObjectSerializer, performance: true do
       t = v[:time]
       factor = t / fast_jsonapi_time
 
-      speed_factor = SERIALIZERS[k].fetch(:speed_factor, 1)
+      speed_factor = SERIALIZERS[k].fetch(:speed_factor) {1}
       result = factor >= speed_factor ? '✔' : '✘'
 
       puts format("%-#{name_length+1}s %-10s %-10s %sx %s", SERIALIZERS[k][:name], count, t.round(2).to_s + ' ms', factor.round(2), result)

--- a/spec/lib/object_serializer_performance_spec.rb
+++ b/spec/lib/object_serializer_performance_spec.rb
@@ -50,6 +50,7 @@ describe FastJsonapi::ObjectSerializer, performance: true do
       options = {}
       options[:meta] = { total: count }
       options[:include] = [:actors]
+      options[:attributes] = [:name]
       expect { MovieSerializer.new(movies, options).serializable_hash }.to perform_under(75).ms
     end
 
@@ -59,6 +60,7 @@ describe FastJsonapi::ObjectSerializer, performance: true do
       options = {}
       options[:meta] = { total: count }
       options[:include] = [:actors]
+      options[:attributes] = [:name]
       expect { MovieSerializer.new(movies, options).serialized_json }.to perform_under(75).ms
     end
   end
@@ -156,7 +158,7 @@ describe FastJsonapi::ObjectSerializer, performance: true do
         options = {}
         options[:meta] = { total: movie_count }
         options[:include] = [:actors, :movie_type]
-
+        
         serializers = {
           fast_jsonapi: MovieSerializer.new(movies, options),
           ams: ActiveModelSerializers::SerializableResource.new(ams_movies, include: options[:include], meta: options[:meta]),

--- a/spec/lib/object_serializer_struct_spec.rb
+++ b/spec/lib/object_serializer_struct_spec.rb
@@ -9,11 +9,12 @@ describe FastJsonapi::ObjectSerializer do
       options[:meta] = { total: 2 }
       options[:links] = { self: 'self' }
       options[:include] = [:actors]
+      options[:attributes] = [:name]
       serializable_hash = MovieSerializer.new([movie_struct, movie_struct], options).serializable_hash
 
       expect(serializable_hash[:data].length).to eq 2
       expect(serializable_hash[:data][0][:relationships].length).to eq 4
-      expect(serializable_hash[:data][0][:attributes].length).to eq 2
+      expect(serializable_hash[:data][0][:attributes].length).to eq 1
 
       expect(serializable_hash[:meta]).to be_instance_of(Hash)
       expect(serializable_hash[:links]).to be_instance_of(Hash)


### PR DESCRIPTION
Adds the option to select the serializer attributes.
This is important so that we do not have to create another serializer to return specific attributes.

Replaces `Hash#fetch+arg` because it is slower than `Hash#fecth+block`

https://github.com/JuanitoFatas/fast-ruby/blob/master/README.md#hashfetch-with-argument-vs-hashfetch--block-code