### PR TITLE
Conditional attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,32 @@ serializer.serializable_hash
 Custom attributes and relationships that only receive the resource are still possible by defining
 the block to only receive one argument.
 
+### Conditional Attributes
+
+Conditional attributes can be defined by passing a Proc to the `if` key on the `attribute` method. Return `true` if the attribute should be serialized, and `false` if not. The record and any params passed to the serializer are available inside the Proc as the first and second parameters, respectively.
+
+```ruby
+class MovieSerializer
+  include FastJsonapi::ObjectSerializer
+
+  attributes :name, :year
+  attribute :release_year, if: Proc.new do |record|
+    # Release year will only be serialized if it's greater than 1990
+    record.release_year > 1990
+  end
+
+  attribute :director, if: Proc.new do |record, params|
+    # The director will be serialized only if the :admin key of params is true
+    params && params[:admin] == true
+  end
+end
+
+# ...
+current_user = User.find(cookies[:current_user_id])
+serializer = MovieSerializer.new(movie, { params: { admin: current_user.admin? }})
+serializer.serializable_hash
+```
+
 ### Customizable Options
 
 Option | Purpose | Example

--- a/lib/fast_jsonapi/attribute.rb
+++ b/lib/fast_jsonapi/attribute.rb
@@ -1,5 +1,5 @@
 module FastJsonapi
-  class AttributeSerializer
+  class Attribute
     attr_reader :key, :method, :conditional_proc
 
     def initialize(key:, method:, options: {})

--- a/lib/fast_jsonapi/attribute_serializer.rb
+++ b/lib/fast_jsonapi/attribute_serializer.rb
@@ -1,0 +1,29 @@
+module FastJsonapi
+  class AttributeSerializer
+    attr_reader :key, :method, :conditional_proc
+
+    def initialize(key:, method:, options: {})
+      @key = key
+      @method = method
+      @conditional_proc = options[:if]
+    end
+
+    def serialize(record, serialization_params, output_hash)
+      if include_attribute?(record, serialization_params)
+        output_hash[key] = if method.is_a?(Proc)
+          method.arity == 1 ? method.call(record) : method.call(record, serialization_params)
+        else
+          record.public_send(method)
+        end
+      end
+    end
+
+    def include_attribute?(record, serialization_params)
+      if conditional_proc.present?
+        conditional_proc.call(record, serialization_params)
+      else
+        true
+      end
+    end
+  end
+end

--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -149,11 +149,18 @@ module FastJsonapi
 
       def attributes(*attributes_list, &block)
         attributes_list = attributes_list.first if attributes_list.first.class.is_a?(Array)
+        options = attributes_list.last.is_a?(Hash) ? attributes_list.pop : {}
         self.attributes_to_serialize = {} if self.attributes_to_serialize.nil?
+        self.optional_attributes_to_serialize = {} if self.optional_attributes_to_serialize.nil?
+
         attributes_list.each do |attr_name|
           method_name = attr_name
           key = run_key_transform(method_name)
-          attributes_to_serialize[key] = block || method_name
+          if options[:if].present?
+            optional_attributes_to_serialize[key] = [method_name, options[:if]]
+          else
+            attributes_to_serialize[key] = block || method_name
+          end
         end
       end
 

--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -3,6 +3,7 @@
 require 'active_support/core_ext/object'
 require 'active_support/concern'
 require 'active_support/inflector'
+require 'fast_jsonapi/attribute_serializer'
 require 'fast_jsonapi/serialization_core'
 
 module FastJsonapi
@@ -151,16 +152,15 @@ module FastJsonapi
         attributes_list = attributes_list.first if attributes_list.first.class.is_a?(Array)
         options = attributes_list.last.is_a?(Hash) ? attributes_list.pop : {}
         self.attributes_to_serialize = {} if self.attributes_to_serialize.nil?
-        self.optional_attributes_to_serialize = {} if self.optional_attributes_to_serialize.nil?
 
         attributes_list.each do |attr_name|
           method_name = attr_name
           key = run_key_transform(method_name)
-          if options[:if].present?
-            optional_attributes_to_serialize[key] = [method_name, options[:if]]
-          else
-            attributes_to_serialize[key] = block || method_name
-          end
+          attributes_to_serialize[key] = AttributeSerializer.new(
+            key: key,
+            method: block || method_name,
+            options: options
+          )
         end
       end
 

--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -3,7 +3,7 @@
 require 'active_support/core_ext/object'
 require 'active_support/concern'
 require 'active_support/inflector'
-require 'fast_jsonapi/attribute_serializer'
+require 'fast_jsonapi/attribute'
 require 'fast_jsonapi/serialization_core'
 
 module FastJsonapi
@@ -156,7 +156,7 @@ module FastJsonapi
         attributes_list.each do |attr_name|
           method_name = attr_name
           key = run_key_transform(method_name)
-          attributes_to_serialize[key] = AttributeSerializer.new(
+          attributes_to_serialize[key] = Attribute.new(
             key: key,
             method: block || method_name,
             options: options

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -12,7 +12,6 @@ module FastJsonapi
     included do
       class << self
         attr_accessor :attributes_to_serialize,
-                      :optional_attributes_to_serialize,
                       :relationships_to_serialize,
                       :cachable_relationships_to_serialize,
                       :uncachable_relationships_to_serialize,
@@ -74,21 +73,9 @@ module FastJsonapi
       end
 
       def attributes_hash(record, params = {})
-        attributes = attributes_to_serialize.each_with_object({}) do |(key, method), attr_hash|
-          attr_hash[key] = if method.is_a?(Proc)
-            method.arity == 1 ? method.call(record) : method.call(record, params)
-          else
-            record.public_send(method)
-          end
+        attributes_to_serialize.each_with_object({}) do |(key, attribute), attr_hash|
+          attribute.serialize(record, params, attr_hash)
         end
-
-        self.optional_attributes_to_serialize = {} if self.optional_attributes_to_serialize.nil?
-        optional_attributes_to_serialize.each do |key, details|
-          method_name, check_proc = details
-          attributes[key] = record.send(method_name) if check_proc.call(record, params)
-        end
-
-        attributes
       end
 
       def relationships_hash(record, relationships = nil, params = {})

--- a/spec/lib/object_serializer_inheritance_spec.rb
+++ b/spec/lib/object_serializer_inheritance_spec.rb
@@ -113,7 +113,7 @@ describe FastJsonapi::ObjectSerializer do
     end
 
     it 'includes child attributes' do
-      expect(EmployeeSerializer.attributes_to_serialize[:location]).to eq(:location)
+      expect(EmployeeSerializer.attributes_to_serialize[:location].method).to eq(:location)
     end
 
     it 'doesnt change parent class attributes' do

--- a/spec/lib/object_serializer_spec.rb
+++ b/spec/lib/object_serializer_spec.rb
@@ -309,4 +309,36 @@ describe FastJsonapi::ObjectSerializer do
       expect(serializable_hash[:included][0][:links][:self]).to eq url
     end
   end
+
+  context 'when optional attributes are determined by record data' do
+    it 'returns optional attribute when attribute is included' do
+      movie.release_year = 2001
+      json = MovieOptionalRecordDataSerializer.new(movie).serialized_json
+      serializable_hash = JSON.parse(json)
+      expect(serializable_hash['data']['attributes']['release_year']).to eq movie.release_year
+    end
+
+    it "doesn't return optional attribute when attribute is not included" do
+      movie.release_year = 1970
+      json = MovieOptionalRecordDataSerializer.new(movie).serialized_json
+      serializable_hash = JSON.parse(json)
+      expect(serializable_hash['data']['attributes'].has_key?('release_year')).to be_falsey
+    end
+  end
+
+  context 'when optional attributes are determined by params data' do
+    it 'returns optional attribute when attribute is included' do
+      movie.director = 'steven spielberg'
+      json = MovieOptionalParamsDataSerializer.new(movie, { params: { admin: true }}).serialized_json
+      serializable_hash = JSON.parse(json)
+      expect(serializable_hash['data']['attributes']['director']).to eq 'steven spielberg'
+    end
+
+    it "doesn't return optional attribute when attribute is not included" do
+      movie.director = 'steven spielberg'
+      json = MovieOptionalParamsDataSerializer.new(movie, { params: { admin: false }}).serialized_json
+      serializable_hash = JSON.parse(json)
+      expect(serializable_hash['data']['attributes'].has_key?('director')).to be_falsey
+    end
+  end
 end

--- a/spec/lib/serialization_core_spec.rb
+++ b/spec/lib/serialization_core_spec.rb
@@ -39,9 +39,9 @@ describe FastJsonapi::ObjectSerializer do
       attributes_hash = MovieSerializer.send(:attributes_hash, movie)
       attribute_names = attributes_hash.keys.sort
       expect(attribute_names).to eq MovieSerializer.attributes_to_serialize.keys.sort
-      MovieSerializer.attributes_to_serialize.each do |key, method_name|
+      MovieSerializer.attributes_to_serialize.each do |key, attribute|
         value = attributes_hash[key]
-        expect(value).to eq movie.send(method_name)
+        expect(value).to eq movie.send(attribute.method)
       end
     end
 

--- a/spec/shared/contexts/movie_context.rb
+++ b/spec/shared/contexts/movie_context.rb
@@ -278,6 +278,20 @@ RSpec.shared_context 'movie class' do
       set_type :account
       belongs_to :supplier
     end
+
+    class MovieOptionalRecordDataSerializer
+      include FastJsonapi::ObjectSerializer
+      set_type :movie
+      attributes :name
+      attribute :release_year, if: Proc.new { |record| record.release_year >= 2000 }
+    end
+
+    class MovieOptionalParamsDataSerializer
+      include FastJsonapi::ObjectSerializer
+      set_type :movie
+      attributes :name
+      attribute :director, if: Proc.new { |record, params| params && params[:admin] == true }
+    end
   end
 
 


### PR DESCRIPTION
_This is mostly code from #66 by @andyjeffries, but the changes were cherry picked and put on top of the current dev branch to fix some tests that were failing._

```ruby
class MovieSerializer
  include FastJsonapi::ObjectSerializer

  attributes :name, :year
  attribute :release_year, if: Proc.new do |record|
    # Release year will only be serialized if it's greater than 1990
    record.release_year > 1990
  end

  attribute :director, if: Proc.new do |record, params|
    # The director will be serialized only if the :admin key of params is true
    params && params[:admin] == true
  end
end

# ...
current_user = User.find(cookies[:current_user_id])
serializer = MovieSerializer.new(movie, { params: { admin: current_user.admin? }})
serializer.serializable_hash
```