### PR TITLE
Conditional relationships

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Fast JSON API serialized 250 records in 3.01 ms
   * [Collection Serialization](#collection-serialization)
   * [Caching](#caching)
   * [Params](#params)
+  * [Conditional Attributes](#conditional-attributes)
+  * [Conditional Relationships](#conditional-relationships)
 * [Contributing](#contributing)
 
 
@@ -325,6 +327,27 @@ class MovieSerializer
     # The director will be serialized only if the :admin key of params is true
     params && params[:admin] == true
   end
+end
+
+# ...
+current_user = User.find(cookies[:current_user_id])
+serializer = MovieSerializer.new(movie, { params: { admin: current_user.admin? }})
+serializer.serializable_hash
+```
+
+### Conditional Relationships
+
+Conditional relationships can be defined by passing a Proc to the `if` key. Return `true` if the relationship should be serialized, and `false` if not. The record and any params passed to the serializer are available inside the Proc as the first and second parameters, respectively.
+
+```ruby
+class MovieSerializer
+  include FastJsonapi::ObjectSerializer
+
+  # Actors will only be serialized if the record has any associated actors
+  has_many :actors, if: Proc.new { |record| record.actors.any? }
+
+  # Owner will only be serialized if the :admin key of params is true
+  belongs_to :owner, if: Proc.new { |record, params| params && params[:admin] == true }
 end
 
 # ...

--- a/lib/fast_jsonapi/link.rb
+++ b/lib/fast_jsonapi/link.rb
@@ -1,0 +1,18 @@
+module FastJsonapi
+  class Link
+    attr_reader :key, :method
+
+    def initialize(key:, method:)
+      @key = key
+      @method = method
+    end
+
+    def serialize(record, serialization_params, output_hash)
+      output_hash[key] = if method.is_a?(Proc)
+        method.arity == 1 ? method.call(record) : method.call(record, serialization_params)
+      else
+        record.public_send(method)
+      end
+    end
+  end
+end

--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -221,7 +221,8 @@ module FastJsonapi
           serializer: compute_serializer_name(options[:serializer] || base_key_sym),
           relationship_type: relationship_type,
           cached: options[:cached] || false,
-          polymorphic: fetch_polymorphic_option(options)
+          polymorphic: fetch_polymorphic_option(options),
+          conditional_proc: options[:if]
         }
       end
 

--- a/lib/fast_jsonapi/relationship.rb
+++ b/lib/fast_jsonapi/relationship.rb
@@ -1,0 +1,99 @@
+module FastJsonapi
+  class Relationship
+    attr_reader :key, :name, :id_method_name, :record_type, :object_method_name, :object_block, :serializer, :relationship_type, :cached, :polymorphic, :conditional_proc
+
+    def initialize(
+      key:,
+      name:,
+      id_method_name:,
+      record_type:,
+      object_method_name:,
+      object_block:,
+      serializer:,
+      relationship_type:,
+      cached: false,
+      polymorphic:,
+      conditional_proc:
+    )
+      @key = key
+      @name = name
+      @id_method_name = id_method_name
+      @record_type = record_type
+      @object_method_name = object_method_name
+      @object_block = object_block
+      @serializer = serializer
+      @relationship_type = relationship_type
+      @cached = cached
+      @polymorphic = polymorphic
+      @conditional_proc = conditional_proc
+    end
+
+    def serialize(record, serialization_params, output_hash)
+      if include_relationship?(record, serialization_params)
+        empty_case = relationship_type == :has_many ? [] : nil
+        output_hash[key] = {
+          data: ids_hash_from_record_and_relationship(record, serialization_params) || empty_case
+        }
+      end
+    end
+
+    def fetch_associated_object(record, params)
+      return object_block.call(record, params) unless object_block.nil?
+      record.send(object_method_name)
+    end
+
+    def include_relationship?(record, serialization_params)
+      if conditional_proc.present?
+        conditional_proc.call(record, serialization_params)
+      else
+        true
+      end
+    end
+
+    private
+
+    def ids_hash_from_record_and_relationship(record, params = {})
+      return ids_hash(
+        fetch_id(record, params)
+      ) unless polymorphic
+
+      return unless associated_object = fetch_associated_object(record, params)
+
+      return associated_object.map do |object|
+        id_hash_from_record object, polymorphic
+      end if associated_object.respond_to? :map
+
+      id_hash_from_record associated_object, polymorphic
+    end
+
+    def id_hash_from_record(record, record_types)
+      # memoize the record type within the record_types dictionary, then assigning to record_type:
+      associated_record_type = record_types[record.class] ||= record.class.name.underscore.to_sym
+      id_hash(record.id, associated_record_type)
+    end
+
+    def ids_hash(ids)
+      return ids.map { |id| id_hash(id, record_type) } if ids.respond_to? :map
+      id_hash(ids, record_type) # ids variable is just a single id here
+    end
+
+    def id_hash(id, record_type, default_return=false)
+      if id.present?
+        { id: id.to_s, type: record_type }
+      else
+        default_return ? { id: nil, type: record_type } : nil
+      end
+    end
+
+    def fetch_id(record, params)
+      unless object_block.nil?
+        object = object_block.call(record, params)
+
+        return object.map(&:id) if object.respond_to? :map
+        return object.try(:id)
+      end
+
+      record.public_send(id_method_name)
+    end
+  end
+end

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -146,6 +146,8 @@ module FastJsonapi
           items = parse_include_item(include_item)
           items.each do |item|
             next unless relationships_to_serialize && relationships_to_serialize[item]
+            conditional_proc = relationships_to_serialize[item][:conditional_proc]
+            next if conditional_proc && !conditional_proc.call(record, params)
             raise NotImplementedError if @relationships_to_serialize[item][:polymorphic].is_a?(Hash)
             record_type = @relationships_to_serialize[item][:record_type]
             serializer = @relationships_to_serialize[item][:serializer].to_s.constantize

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -34,47 +34,15 @@ module FastJsonapi
         end
       end
 
-      def ids_hash(ids, record_type)
-        return ids.map { |id| id_hash(id, record_type) } if ids.respond_to? :map
-        id_hash(ids, record_type) # ids variable is just a single id here
-      end
-
-      def id_hash_from_record(record, record_types)
-        # memoize the record type within the record_types dictionary, then assigning to record_type:
-        record_type = record_types[record.class] ||= record.class.name.underscore.to_sym
-        id_hash(record.id, record_type)
-      end
-
-      def ids_hash_from_record_and_relationship(record, relationship, params = {})
-        polymorphic = relationship[:polymorphic]
-
-        return ids_hash(
-          fetch_id(record, relationship, params),
-          relationship[:record_type]
-        ) unless polymorphic
-
-        return unless associated_object = fetch_associated_object(record, relationship, params)
-
-        return associated_object.map do |object|
-          id_hash_from_record object, polymorphic
-        end if associated_object.respond_to? :map
-
-        id_hash_from_record associated_object, polymorphic
-      end
-
       def links_hash(record, params = {})
-        data_links.each_with_object({}) do |(key, method), link_hash|
-          link_hash[key] = if method.is_a?(Proc)
-            method.arity == 1 ? method.call(record) : method.call(record, params)
-          else
-            record.public_send(method)
-          end
+        data_links.each_with_object({}) do |(_k, link), hash|
+          link.serialize(record, params, hash)
         end
       end
 
       def attributes_hash(record, params = {})
-        attributes_to_serialize.each_with_object({}) do |(key, attribute), attr_hash|
-          attribute.serialize(record, params, attr_hash)
+        attributes_to_serialize.each_with_object({}) do |(_k, attribute), hash|
+          attribute.serialize(record, params, hash)
         end
       end
 
@@ -82,14 +50,7 @@ module FastJsonapi
         relationships = relationships_to_serialize if relationships.nil?
 
         relationships.each_with_object({}) do |(_k, relationship), hash|
-          conditional_proc = relationship[:conditional_proc]
-          if conditional_proc.blank? || conditional_proc.call(record, params)
-            name = relationship[:key]
-            empty_case = relationship[:relationship_type] == :has_many ? [] : nil
-            hash[name] = {
-              data: ids_hash_from_record_and_relationship(record, relationship, params) || empty_case
-            }
-          end
+          relationship.serialize(record, params, hash)
         end
       end
 
@@ -146,14 +107,14 @@ module FastJsonapi
           items = parse_include_item(include_item)
           items.each do |item|
             next unless relationships_to_serialize && relationships_to_serialize[item]
-            conditional_proc = relationships_to_serialize[item][:conditional_proc]
-            next if conditional_proc && !conditional_proc.call(record, params)
-            raise NotImplementedError if @relationships_to_serialize[item][:polymorphic].is_a?(Hash)
-            record_type = @relationships_to_serialize[item][:record_type]
-            serializer = @relationships_to_serialize[item][:serializer].to_s.constantize
-            relationship_type = @relationships_to_serialize[item][:relationship_type]
+            relationship_item = relationships_to_serialize[item]
+            next unless relationship_item.include_relationship?(record, params)
+            raise NotImplementedError if relationship_item.polymorphic.is_a?(Hash)
+            record_type = relationship_item.record_type
+            serializer = relationship_item.serializer.to_s.constantize
+            relationship_type = relationship_item.relationship_type
 
-            included_objects = fetch_associated_object(record, @relationships_to_serialize[item], params)
+            included_objects = relationship_item.fetch_associated_object(record, params)
             next if included_objects.blank?
             included_objects = [included_objects] unless relationship_type == :has_many
 
@@ -171,22 +132,6 @@ module FastJsonapi
             end
           end
         end
-      end
-
-      def fetch_associated_object(record, relationship, params)
-        return relationship[:object_block].call(record, params) unless relationship[:object_block].nil?
-        record.send(relationship[:object_method_name])
-      end
-
-      def fetch_id(record, relationship, params)
-        unless relationship[:object_block].nil?
-          object = relationship[:object_block].call(record, params)
-
-          return object.map(&:id) if object.respond_to? :map
-          return object.try(:id)
-        end
-
-        record.public_send(relationship[:id_method_name])
       end
     end
   end

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -82,11 +82,14 @@ module FastJsonapi
         relationships = relationships_to_serialize if relationships.nil?
 
         relationships.each_with_object({}) do |(_k, relationship), hash|
-          name = relationship[:key]
-          empty_case = relationship[:relationship_type] == :has_many ? [] : nil
-          hash[name] = {
-            data: ids_hash_from_record_and_relationship(record, relationship, params) || empty_case
-          }
+          conditional_proc = relationship[:conditional_proc]
+          if conditional_proc.blank? || conditional_proc.call(record, params)
+            name = relationship[:key]
+            empty_case = relationship[:relationship_type] == :has_many ? [] : nil
+            hash[name] = {
+              data: ids_hash_from_record_and_relationship(record, relationship, params) || empty_case
+            }
+          end
         end
       end
 

--- a/spec/lib/object_serializer_spec.rb
+++ b/spec/lib/object_serializer_spec.rb
@@ -361,13 +361,13 @@ describe FastJsonapi::ObjectSerializer do
     it 'returns optional relationship when relationship is included' do
       json = MovieOptionalRelationshipWithParamsSerializer.new(movie, { params: { admin: true }}).serialized_json
       serializable_hash = JSON.parse(json)
-      expect(serializable_hash['data']['relationships'].has_key?('actors')).to be_truthy
+      expect(serializable_hash['data']['relationships'].has_key?('owner')).to be_truthy
     end
 
     it "doesn't return optional relationship when relationship is not included" do
       json = MovieOptionalRelationshipWithParamsSerializer.new(movie, { params: { admin: false }}).serialized_json
       serializable_hash = JSON.parse(json)
-      expect(serializable_hash['data']['relationships'].has_key?('actors')).to be_falsey
+      expect(serializable_hash['data']['relationships'].has_key?('owner')).to be_falsey
     end
   end
 end

--- a/spec/lib/object_serializer_spec.rb
+++ b/spec/lib/object_serializer_spec.rb
@@ -349,11 +349,27 @@ describe FastJsonapi::ObjectSerializer do
       expect(serializable_hash['data']['relationships'].has_key?('actors')).to be_truthy
     end
 
-    it "doesn't return optional relationship when relationship is not included" do
-      movie.actor_ids = []
-      json = MovieOptionalRelationshipSerializer.new(movie).serialized_json
-      serializable_hash = JSON.parse(json)
-      expect(serializable_hash['data']['relationships'].has_key?('actors')).to be_falsey
+    context "when relationship is not included" do
+      let(:json) {
+        MovieOptionalRelationshipSerializer.new(movie, options).serialized_json
+      }
+      let(:options) {
+        {}
+      }
+      let(:serializable_hash) {
+        JSON.parse(json)
+      }
+
+      it "doesn't return optional relationship" do
+        movie.actor_ids = []
+        expect(serializable_hash['data']['relationships'].has_key?('actors')).to be_falsey
+      end
+
+      it "doesn't include optional relationship" do
+        movie.actor_ids = []
+        options[:include] = [:actors]
+        expect(serializable_hash['included']).to be_blank
+      end
     end
   end
 
@@ -364,10 +380,25 @@ describe FastJsonapi::ObjectSerializer do
       expect(serializable_hash['data']['relationships'].has_key?('owner')).to be_truthy
     end
 
-    it "doesn't return optional relationship when relationship is not included" do
-      json = MovieOptionalRelationshipWithParamsSerializer.new(movie, { params: { admin: false }}).serialized_json
-      serializable_hash = JSON.parse(json)
-      expect(serializable_hash['data']['relationships'].has_key?('owner')).to be_falsey
+    context "when relationship is not included" do
+      let(:json) {
+        MovieOptionalRelationshipWithParamsSerializer.new(movie, options).serialized_json
+      }
+      let(:options) {
+        { params: { admin: false }}
+      }
+      let(:serializable_hash) {
+        JSON.parse(json)
+      }
+
+      it "doesn't return optional relationship" do
+        expect(serializable_hash['data']['relationships'].has_key?('owner')).to be_falsey
+      end
+
+      it "doesn't include optional relationship" do
+        options[:include] = [:owner]
+        expect(serializable_hash['included']).to be_blank
+      end
     end
   end
 end

--- a/spec/lib/object_serializer_spec.rb
+++ b/spec/lib/object_serializer_spec.rb
@@ -341,4 +341,33 @@ describe FastJsonapi::ObjectSerializer do
       expect(serializable_hash['data']['attributes'].has_key?('director')).to be_falsey
     end
   end
+
+  context 'when optional relationships are determined by record data' do
+    it 'returns optional relationship when relationship is included' do
+      json = MovieOptionalRelationshipSerializer.new(movie).serialized_json
+      serializable_hash = JSON.parse(json)
+      expect(serializable_hash['data']['relationships'].has_key?('actors')).to be_truthy
+    end
+
+    it "doesn't return optional relationship when relationship is not included" do
+      movie.actor_ids = []
+      json = MovieOptionalRelationshipSerializer.new(movie).serialized_json
+      serializable_hash = JSON.parse(json)
+      expect(serializable_hash['data']['relationships'].has_key?('actors')).to be_falsey
+    end
+  end
+
+  context 'when optional relationships are determined by params data' do
+    it 'returns optional relationship when relationship is included' do
+      json = MovieOptionalRelationshipWithParamsSerializer.new(movie, { params: { admin: true }}).serialized_json
+      serializable_hash = JSON.parse(json)
+      expect(serializable_hash['data']['relationships'].has_key?('actors')).to be_truthy
+    end
+
+    it "doesn't return optional relationship when relationship is not included" do
+      json = MovieOptionalRelationshipWithParamsSerializer.new(movie, { params: { admin: false }}).serialized_json
+      serializable_hash = JSON.parse(json)
+      expect(serializable_hash['data']['relationships'].has_key?('actors')).to be_falsey
+    end
+  end
 end

--- a/spec/lib/serialization_core_spec.rb
+++ b/spec/lib/serialization_core_spec.rb
@@ -17,24 +17,6 @@ describe FastJsonapi::ObjectSerializer do
       expect(result_hash).to be nil
     end
 
-    it 'returns the correct hash when ids_hash_from_record_and_relationship is called for a polymorphic association' do
-      relationship = { name: :groupees, relationship_type: :has_many, object_method_name: :groupees, polymorphic: {} }
-      results = GroupSerializer.send :ids_hash_from_record_and_relationship, group, relationship
-      expect(results).to include({ id: "1", type: :person }, { id: "2", type: :group })
-    end
-
-    it 'returns correct hash when ids_hash is called' do
-      inputs = [{ids: %w(1 2 3), record_type: :movie}, {ids: %w(x y z), record_type: 'person'}]
-      inputs.each do |hash|
-        results = MovieSerializer.send(:ids_hash, hash[:ids], hash[:record_type])
-        expect(results.map{|h| h[:id]}).to eq hash[:ids]
-        expect(results[0][:type]).to eq hash[:record_type]
-      end
-
-      result = MovieSerializer.send(:ids_hash, [], 'movie')
-      expect(result).to be_empty
-    end
-
     it 'returns correct hash when attributes_hash is called' do
       attributes_hash = MovieSerializer.send(:attributes_hash, movie)
       attribute_names = attributes_hash.keys.sort
@@ -57,7 +39,7 @@ describe FastJsonapi::ObjectSerializer do
       relationships_hash = MovieSerializer.send(:relationships_hash, movie)
       relationship_names = relationships_hash.keys.sort
       relationships_hashes = MovieSerializer.relationships_to_serialize.values
-      expected_names = relationships_hashes.map{|relationship| relationship[:key]}.sort
+      expected_names = relationships_hashes.map{|relationship| relationship.key}.sort
       expect(relationship_names).to eq expected_names
     end
 

--- a/spec/shared/contexts/movie_context.rb
+++ b/spec/shared/contexts/movie_context.rb
@@ -292,6 +292,20 @@ RSpec.shared_context 'movie class' do
       attributes :name
       attribute :director, if: Proc.new { |record, params| params && params[:admin] == true }
     end
+
+    class MovieOptionalRelationshipSerializer
+      include FastJsonapi::ObjectSerializer
+      set_type :movie
+      attributes :name
+      has_many :actors, if: Proc.new { |record| record.actors.any? }
+    end
+
+    class MovieOptionalRelationshipWithParamsSerializer
+      include FastJsonapi::ObjectSerializer
+      set_type :movie
+      attributes :name
+      has_many :actors, if: Proc.new { |record, params| params && params[:admin] == true }
+    end
   end
 
 

--- a/spec/shared/contexts/movie_context.rb
+++ b/spec/shared/contexts/movie_context.rb
@@ -304,7 +304,7 @@ RSpec.shared_context 'movie class' do
       include FastJsonapi::ObjectSerializer
       set_type :movie
       attributes :name
-      has_many :actors, if: Proc.new { |record, params| params && params[:admin] == true }
+      belongs_to :owner, record_type: :user, if: Proc.new { |record, params| params && params[:admin] == true }
     end
   end
 

--- a/spec/shared/examples/object_serializer_class_methods_examples.rb
+++ b/spec/shared/examples/object_serializer_class_methods_examples.rb
@@ -1,10 +1,10 @@
 RSpec.shared_examples 'returning correct relationship hash' do |serializer, id_method_name, record_type|
   it 'returns correct relationship hash' do
-    expect(relationship).to be_instance_of(Hash)
-    expect(relationship.keys).to all(be_instance_of(Symbol))
-    expect(relationship[:serializer]).to be serializer
-    expect(relationship[:id_method_name]).to be id_method_name
-    expect(relationship[:record_type]).to be record_type
+    expect(relationship).to be_instance_of(FastJsonapi::Relationship)
+    # expect(relationship.keys).to all(be_instance_of(Symbol))
+    expect(relationship.serializer).to be serializer
+    expect(relationship.id_method_name).to be id_method_name
+    expect(relationship.record_type).to be record_type
   end
 end
 


### PR DESCRIPTION
Just like conditional attributes, conditional relationships can be defined by passing a Proc to the `if` key.

```
class MovieSerializer
  include FastJsonapi::ObjectSerializer

  # Actors will only be serialized if the record has any associated actors
  has_many :actors, if: Proc.new { |record| record.actors.any? }

  # Owner will only be serialized if the :admin key of params is true
  belongs_to :owner, if: Proc.new { |record, params| params && params[:admin] == true }
end

# ...
current_user = User.find(cookies[:current_user_id])
serializer = MovieSerializer.new(movie, { params: { admin: current_user.admin? }})
serializer.serializable_hash
```