### PR TITLE
Remove duplicated MovieSerializer in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,6 @@ block you opt-in to using params by adding it as a block parameter.
 
 ```ruby
 class MovieSerializer
-  class MovieSerializer
   include FastJsonapi::ObjectSerializer
 
   attributes :name, :year


### PR DESCRIPTION
There was just a typo in an example. 