### PR TITLE
Allow passing procs with variable arguments when declaring an attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,18 @@ class MovieSerializer
 end
 ```
 
+Attributes can also use a different name by passing the original method or accessor with a proc shortcut:
+
+```ruby
+class MovieSerializer
+  include FastJsonapi::ObjectSerializer
+
+  attributes :name
+
+  attribute :released_in_year, &:year
+end
+```
+
 ### Links Per Object
 Links are defined in FastJsonapi using the `link` method. By default, link are read directly from the model property of the same name.In this example, `public_url` is expected to be a property of the object being serialized.
 

--- a/lib/fast_jsonapi/attribute.rb
+++ b/lib/fast_jsonapi/attribute.rb
@@ -11,7 +11,7 @@ module FastJsonapi
     def serialize(record, serialization_params, output_hash)
       if include_attribute?(record, serialization_params)
         output_hash[key] = if method.is_a?(Proc)
-          method.arity == 1 ? method.call(record) : method.call(record, serialization_params)
+          method.arity.abs == 1 ? method.call(record) : method.call(record, serialization_params)
         else
           record.public_send(method)
         end

--- a/spec/lib/object_serializer_class_methods_spec.rb
+++ b/spec/lib/object_serializer_class_methods_spec.rb
@@ -235,6 +235,7 @@ describe FastJsonapi::ObjectSerializer do
       before do
         movie.release_year = 2008
         MovieSerializer.attribute :released_in_year, &:release_year
+        MovieSerializer.attribute :name, &:local_name
       end
 
       after do
@@ -242,7 +243,7 @@ describe FastJsonapi::ObjectSerializer do
       end
 
       it 'returns correct hash when serializable_hash is called' do
-        expect(serializable_hash[:data][:attributes][:name]).to eq movie.name
+        expect(serializable_hash[:data][:attributes][:name]).to eq "english #{movie.name}"
         expect(serializable_hash[:data][:attributes][:released_in_year]).to eq movie.release_year
       end
     end

--- a/spec/lib/object_serializer_class_methods_spec.rb
+++ b/spec/lib/object_serializer_class_methods_spec.rb
@@ -230,6 +230,22 @@ describe FastJsonapi::ObjectSerializer do
         expect(serializable_hash[:data][:attributes][:title_with_year]).to eq "#{movie.name} (#{movie.release_year})"
       end
     end
+
+    context 'with &:proc' do
+      before do
+        movie.release_year = 2008
+        MovieSerializer.attribute :released_in_year, &:release_year
+      end
+
+      after do
+        MovieSerializer.attributes_to_serialize.delete(:released_in_year)
+      end
+
+      it 'returns correct hash when serializable_hash is called' do
+        expect(serializable_hash[:data][:attributes][:name]).to eq movie.name
+        expect(serializable_hash[:data][:attributes][:released_in_year]).to eq movie.release_year
+      end
+    end
   end
 
   describe '#link' do

--- a/spec/shared/contexts/movie_context.rb
+++ b/spec/shared/contexts/movie_context.rb
@@ -54,6 +54,10 @@ RSpec.shared_context 'movie class' do
         "#{id}"
       end
 
+      def local_name(locale = :english)
+        "#{locale} #{name}"
+      end
+
       def url
         "http://movies.com/#{id}"
       end


### PR DESCRIPTION
Allows procs with variable arguments to be used in an attribute declaration, which will also allow the usage of `&:proc`. Instead of having to write something like:

```
class MovieSerializer
  attribute :released_in_year do |object|
    object.release_year
  end
end
```

We can instead write:

```
class MovieSerializer
  attribute :released_in_year, &:release_year
end
```