### PR TITLE
Allow the serializer to return sparse fieldsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Fast JSON API serialized 250 records in 3.01 ms
   * [Params](#params)
   * [Conditional Attributes](#conditional-attributes)
   * [Conditional Relationships](#conditional-relationships)
+  * [Sparse Fieldsets](#sparse-fieldsets)
 * [Contributing](#contributing)
 
 
@@ -373,6 +374,21 @@ end
 # ...
 current_user = User.find(cookies[:current_user_id])
 serializer = MovieSerializer.new(movie, { params: { admin: current_user.admin? }})
+serializer.serializable_hash
+```
+
+### Sparse Fieldsets
+
+Attributes and relationships can be selectively returned per record type by using the `fields` option.
+
+```ruby
+class MovieSerializer
+  include FastJsonapi::ObjectSerializer
+
+  attributes :name, :year
+end
+
+serializer = MovieSerializer.new(movie, { fields: { movie: [:name] } })
 serializer.serializable_hash
 ```
 

--- a/lib/fast_jsonapi/fieldset.rb
+++ b/lib/fast_jsonapi/fieldset.rb
@@ -1,7 +1,0 @@
-module FastJsonapi
-  class Fieldset
-    def initialize(fields)
-      @fields = fields
-    end
-  end
-end

--- a/lib/fast_jsonapi/fieldset.rb
+++ b/lib/fast_jsonapi/fieldset.rb
@@ -1,0 +1,7 @@
+module FastJsonapi
+  class Fieldset
+    def initialize(fields)
+      @fields = fields
+    end
+  end
+end

--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -41,7 +41,7 @@ module FastJsonapi
 
       return serializable_hash unless @resource
 
-      serializable_hash[:data] = self.class.record_hash(@resource, @fieldsets[self.class.reflected_record_type.to_sym], @params)
+      serializable_hash[:data] = self.class.record_hash(@resource, @fieldsets[self.class.record_type.to_sym], @params)
       serializable_hash[:included] = self.class.get_included_records(@resource, @includes, @known_included_objects, @fieldsets, @params) if @includes.present?
       serializable_hash
     end
@@ -51,7 +51,7 @@ module FastJsonapi
 
       data = []
       included = []
-      fieldset = @fieldsets[self.class.reflected_record_type.to_sym]
+      fieldset = @fieldsets[self.class.record_type.to_sym]
       @resource.each do |record|
         data << self.class.record_hash(record, fieldset, @params)
         included.concat self.class.get_included_records(record, @includes, @known_included_objects, @fieldsets, @params) if @includes.present?

--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -119,6 +119,7 @@ module FastJsonapi
         subclass.race_condition_ttl = race_condition_ttl
         subclass.data_links = data_links
         subclass.cached = cached
+        subclass.set_type(subclass.reflected_record_type) if subclass.reflected_record_type
       end
 
       def reflected_record_type

--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -7,7 +7,6 @@ require 'fast_jsonapi/attribute'
 require 'fast_jsonapi/relationship'
 require 'fast_jsonapi/link'
 require 'fast_jsonapi/serialization_core'
-require 'fast_jsonapi/fieldset'
 
 module FastJsonapi
   module ObjectSerializer
@@ -120,7 +119,6 @@ module FastJsonapi
         subclass.race_condition_ttl = race_condition_ttl
         subclass.data_links = data_links
         subclass.cached = cached
-        subclass.fieldset = fieldset.dup if fieldset.present?
       end
 
       def reflected_record_type

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -21,8 +21,7 @@ module FastJsonapi
                       :cache_length,
                       :race_condition_ttl,
                       :cached,
-                      :data_links,
-                      :fieldset
+                      :data_links
       end
     end
 

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -132,7 +132,7 @@ module FastJsonapi
 
               known_included_objects[code] = inc_obj
 
-              included_records << serializer.record_hash(inc_obj, fieldsets[serializer.reflected_record_type], params)
+              included_records << serializer.record_hash(inc_obj, fieldsets[serializer.record_type], params)
             end
           end
         end

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -21,7 +21,8 @@ module FastJsonapi
                       :cache_length,
                       :race_condition_ttl,
                       :cached,
-                      :data_links
+                      :data_links,
+                      :fieldset
       end
     end
 
@@ -40,27 +41,30 @@ module FastJsonapi
         end
       end
 
-      def attributes_hash(record, params = {})
-        attributes_to_serialize.each_with_object({}) do |(_k, attribute), hash|
+      def attributes_hash(record, fieldset = nil, params = {})
+        attributes = attributes_to_serialize
+        attributes = attributes.slice(*fieldset) if fieldset.present?
+        attributes.each_with_object({}) do |(_k, attribute), hash|
           attribute.serialize(record, params, hash)
         end
       end
 
-      def relationships_hash(record, relationships = nil, params = {})
+      def relationships_hash(record, relationships = nil, fieldset = nil, params = {})
         relationships = relationships_to_serialize if relationships.nil?
+        relationships = relationships.slice(*fieldset) if fieldset.present?
 
         relationships.each_with_object({}) do |(_k, relationship), hash|
           relationship.serialize(record, params, hash)
         end
       end
 
-      def record_hash(record, params = {})
+      def record_hash(record, fieldset, params = {})
         if cached
           record_hash = Rails.cache.fetch(record.cache_key, expires_in: cache_length, race_condition_ttl: race_condition_ttl) do
             temp_hash = id_hash(id_from_record(record), record_type, true)
-            temp_hash[:attributes] = attributes_hash(record, params) if attributes_to_serialize.present?
+            temp_hash[:attributes] = attributes_hash(record, fieldset, params) if attributes_to_serialize.present?
             temp_hash[:relationships] = {}
-            temp_hash[:relationships] = relationships_hash(record, cachable_relationships_to_serialize, params) if cachable_relationships_to_serialize.present?
+            temp_hash[:relationships] = relationships_hash(record, cachable_relationships_to_serialize, fieldset, params) if cachable_relationships_to_serialize.present?
             temp_hash[:links] = links_hash(record, params) if data_links.present?
             temp_hash
           end
@@ -68,8 +72,8 @@ module FastJsonapi
           record_hash
         else
           record_hash = id_hash(id_from_record(record), record_type, true)
-          record_hash[:attributes] = attributes_hash(record, params) if attributes_to_serialize.present?
-          record_hash[:relationships] = relationships_hash(record, nil, params) if relationships_to_serialize.present?
+          record_hash[:attributes] = attributes_hash(record, fieldset, params) if attributes_to_serialize.present?
+          record_hash[:relationships] = relationships_hash(record, nil, fieldset, params) if relationships_to_serialize.present?
           record_hash[:links] = links_hash(record, params) if data_links.present?
           record_hash
         end
@@ -100,7 +104,7 @@ module FastJsonapi
       end
 
       # includes handler
-      def get_included_records(record, includes_list, known_included_objects, params = {})
+      def get_included_records(record, includes_list, known_included_objects, fieldsets, params = {})
         return unless includes_list.present?
 
         includes_list.sort.each_with_object([]) do |include_item, included_records|
@@ -120,7 +124,7 @@ module FastJsonapi
 
             included_objects.each do |inc_obj|
               if remaining_items(items)
-                serializer_records = serializer.get_included_records(inc_obj, remaining_items(items), known_included_objects)
+                serializer_records = serializer.get_included_records(inc_obj, remaining_items(items), known_included_objects, fieldsets)
                 included_records.concat(serializer_records) unless serializer_records.empty?
               end
 
@@ -128,7 +132,8 @@ module FastJsonapi
               next if known_included_objects.key?(code)
 
               known_included_objects[code] = inc_obj
-              included_records << serializer.record_hash(inc_obj, params)
+
+              included_records << serializer.record_hash(inc_obj, fieldsets[serializer.reflected_record_type], params)
             end
           end
         end

--- a/spec/lib/object_serializer_fields_spec.rb
+++ b/spec/lib/object_serializer_fields_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe FastJsonapi::ObjectSerializer do
+  include_context 'movie class'
+
+  let(:fields) do
+    {
+      movie: %i[name actors],
+      actor: %i[name agency]
+    }
+  end
+
+  it 'only returns specified fields' do
+    hash = MovieSerializer.new(movie, fields: fields).serializable_hash
+
+    expect(hash[:data][:attributes].keys.sort).to eq %i[name]
+  end
+
+  it 'only returns specified relationships' do
+    hash = MovieSerializer.new(movie, fields: fields).serializable_hash
+
+    expect(hash[:data][:relationships].keys.sort).to eq %i[actors]
+  end
+
+  it 'only returns specified fields for included relationships' do
+    hash = MovieSerializer.new(movie, fields: fields, include: %i[actors]).serializable_hash
+
+    expect(hash[:included].first[:attributes].keys.sort).to eq %i[name]
+  end
+
+  it 'only returns specified relationships for included relationships' do
+    hash = MovieSerializer.new(movie, fields: fields, include: %i[actors]).serializable_hash
+
+    expect(hash[:included].first[:relationships].keys.sort).to eq %i[agency]
+  end
+end

--- a/spec/lib/object_serializer_fields_spec.rb
+++ b/spec/lib/object_serializer_fields_spec.rb
@@ -5,7 +5,7 @@ describe FastJsonapi::ObjectSerializer do
 
   let(:fields) do
     {
-      movie: %i[name actors],
+      movie: %i[name actors advertising_campaign],
       actor: %i[name agency]
     }
   end
@@ -19,7 +19,7 @@ describe FastJsonapi::ObjectSerializer do
   it 'only returns specified relationships' do
     hash = MovieSerializer.new(movie, fields: fields).serializable_hash
 
-    expect(hash[:data][:relationships].keys.sort).to eq %i[actors]
+    expect(hash[:data][:relationships].keys.sort).to eq %i[actors advertising_campaign]
   end
 
   it 'only returns specified fields for included relationships' do
@@ -29,8 +29,20 @@ describe FastJsonapi::ObjectSerializer do
   end
 
   it 'only returns specified relationships for included relationships' do
-    hash = MovieSerializer.new(movie, fields: fields, include: %i[actors]).serializable_hash
+    hash = MovieSerializer.new(movie, fields: fields, include: %i[actors advertising_campaign]).serializable_hash
 
     expect(hash[:included].first[:relationships].keys.sort).to eq %i[agency]
+  end
+
+  it 'returns all fields for included relationships when no explicit fields have been specified' do
+    hash = MovieSerializer.new(movie, fields: fields, include: %i[actors advertising_campaign]).serializable_hash
+
+    expect(hash[:included][3][:attributes].keys.sort).to eq %i[id name]
+  end
+
+  it 'returns all fields for included relationships when no explicit fields have been specified' do
+    hash = MovieSerializer.new(movie, fields: fields, include: %i[actors advertising_campaign]).serializable_hash
+
+    expect(hash[:included][3][:relationships].keys.sort).to eq %i[movie]
   end
 end

--- a/spec/lib/object_serializer_inheritance_spec.rb
+++ b/spec/lib/object_serializer_inheritance_spec.rb
@@ -95,6 +95,11 @@ describe FastJsonapi::ObjectSerializer do
     has_one :account
   end
 
+  it 'sets the correct record type' do
+    expect(EmployeeSerializer.reflected_record_type).to eq :employee
+    expect(EmployeeSerializer.record_type).to eq :employee
+  end
+
   context 'when testing inheritance of attributes' do
 
     it 'includes parent attributes' do

--- a/spec/lib/serialization_core_spec.rb
+++ b/spec/lib/serialization_core_spec.rb
@@ -64,7 +64,7 @@ describe FastJsonapi::ObjectSerializer do
       known_included_objects = {}
       included_records = []
       [movie, movie].each do |record|
-        included_records.concat MovieSerializer.send(:get_included_records, record, includes_list, known_included_objects, nil)
+        included_records.concat MovieSerializer.send(:get_included_records, record, includes_list, known_included_objects, {}, nil)
       end
       expect(included_records.size).to eq 3
     end


### PR DESCRIPTION
I also need sparse fieldset support from Fast JSON API. After reading through and seeing that there's no recent activity on #57, #63, and #254, I'd like to take a stab at this.

A client should be able to request only a subset of attributes and relationships using the `fields` option. Here's an example using the movie context from the test suite:

```ruby
options = {
  fields: {
    movie: %i[name actors advertising_campaign],
    actor: %i[name agency]
  },
  include: %i[actors advertising_campaign]
}

MovieSerializer.new(movie, options).serialized_json
```

Note that this would respect both attributes and relationships when the fields have been explicitly given. The resulting `movie` would only return `name` in its `attributes`, and only `actors`, `advertising_campaign` would be retured in its `relationships`.

Fields will also be filtered on included documents. All `actor` will only return `name` and `agency` on their `attributes` and `relationships` respectively.

Records which do not have explicit fields will return all its attributes and relationships, as shown by `advertising_campaign`.

Here's the full JSON:

```json
{
  "data":{
    "id":"232",
    "type":"movie",
    "attributes":{
      "name":"test movie"
    },
    "relationships":{
      "actors":{
        "data":[
          {
            "id":"1",
            "type":"actor"
          },
          {
            "id":"2",
            "type":"actor"
          },
          {
            "id":"3",
            "type":"actor"
          }
        ]
      },
      "advertising_campaign":{
        "data":{
          "id":"1",
          "type":"advertising_campaign"
        }
      }
    }
  },
  "included":[
    {
      "id":"1",
      "type":"actor",
      "attributes":{
        "name":"Test 1"
      },
      "relationships":{
        "agency":{
          "data":{
            "id":"0",
            "type":"agency"
          }
        }
      }
    },
    {
      "id":"2",
      "type":"actor",
      "attributes":{
        "name":"Test 2"
      },
      "relationships":{
        "agency":{
          "data":{
            "id":"1",
            "type":"agency"
          }
        }
      }
    },
    {
      "id":"3",
      "type":"actor",
      "attributes":{
        "name":"Test 3"
      },
      "relationships":{
        "agency":{
          "data":{
            "id":"2",
            "type":"agency"
          }
        }
      }
    },
    {
      "id":"1",
      "type":"advertising_campaign",
      "attributes":{
        "id":1,
        "name":"Movie test movie is incredible!!"
      },
      "relationships":{
        "movie":{
          "data":{
            "id":"232",
            "type":"movie"
          }
        }
      }
    }
  ]
}
```