### PR TITLE
Fix confusing error when using include and no relationship was set

### DIFF
--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -275,7 +275,8 @@ module FastJsonapi
         includes.detect do |include_item|
           klass = self
           parse_include_item(include_item).each do |parsed_include|
-            relationship_to_include = klass.relationships_to_serialize[parsed_include]
+            relationships_to_serialize = klass.relationships_to_serialize || {}
+            relationship_to_include = relationships_to_serialize[parsed_include]
             raise ArgumentError, "#{parsed_include} is not specified as a relationship on #{klass.name}" unless relationship_to_include
             raise NotImplementedError if relationship_to_include.polymorphic.is_a?(Hash)
             klass = relationship_to_include.serializer.to_s.constantize


### PR DESCRIPTION
If you forgot to set any `has_many` in the serializer and tried to serialize with an `include` you would get:
```
NoMethodError (undefined method `[]' for nil:NilClass):
```

(no backtrace from the gem) That is not very helpful.

Setting the variable with a default case makes sure the right error message gets displayed.