### PR TITLE
Fix weak entities case (id is not meaningful attribute) with include.

### DIFF
--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -134,7 +134,7 @@ module FastJsonapi
                 included_records.concat(serializer_records) unless serializer_records.empty?
               end
 
-              code = "#{record_type}_#{inc_obj.id}"
+              code = "#{record_type}_#{serializer.id_from_record(inc_obj)}"
               next if known_included_objects.key?(code)
 
               known_included_objects[code] = inc_obj


### PR DESCRIPTION
The problem occurs if the entity has `id` method, but it's not a primary key and not the id for the serializers, i.e. `set_id` was used, e.g. if you use sequel and have a weak entity, who's primary key is not id. In this case `id` method will return `nil`. During serialization `nil` returned from `id` is used for duplicates elimination for `include` and therefore only first entity is serialized.

The new test with the old code is failing with
```
       expected: ["actor0@email.com", "actor1@email.com", "actor2@email.com"]
            got: ["actor0@email.com"]
```