### PR TITLE
Adds a :links option to the relationship macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,17 +262,15 @@ class MovieSerializer
 end
 ```
 
-This will create a `self` reference for the relationship, and a `related` link for loading the actors relationship later. NB: This will not automatically disable including the data in the relationship, you'll need to do that using the yielded block:
+This will create a `self` reference for the relationship, and a `related` link for loading the actors relationship later. NB: This will not automatically disable loading the data in the relationship, you'll need to do that using the `lazy_load_data` option:
 
 ```ruby
-  has_many :actors, links: {
+  has_many :actors, lazy_load_data: true, links: {
     self: :url,
     related: -> (object) {
       "https://movies.com/#{object.id}/actors"
     }
-  } do |movie|
-    movie.actors.limit(5)
-  end
+  }
 ```
 
 ### Meta Per Resource

--- a/README.md
+++ b/README.md
@@ -245,6 +245,36 @@ class MovieSerializer
 end
 ```
 
+#### Links on a Relationship
+
+You can specify [relationship links](http://jsonapi.org/format/#document-resource-object-relationships) by using the `links:` option on the serializer. Relationship links in JSON API are useful if you want to load a parent document and then load associated documents later due to size constraints (see [related resource links](http://jsonapi.org/format/#document-resource-object-related-resource-links))
+
+```ruby
+class MovieSerializer
+  include FastJsonapi::ObjectSerializer
+
+  has_many :actors, links: {
+    self: :url,
+    related: -> (object) {
+      "https://movies.com/#{object.id}/actors"
+    }
+  }
+end
+```
+
+This will create a `self` reference for the relationship, and a `related` link for loading the actors relationship later. NB: This will not automatically disable including the data in the relationship, you'll need to do that using the yielded block:
+
+```ruby
+  has_many :actors, links: {
+    self: :url,
+    related: -> (object) {
+      "https://movies.com/#{object.id}/actors"
+    }
+  } do |movie|
+    movie.actors.limit(5)
+  end
+```
+
 ### Compound Document
 
 Support for top-level and nested included associations through ` options[:include] `.

--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -250,7 +250,8 @@ module FastJsonapi
           cached: options[:cached],
           polymorphic: fetch_polymorphic_option(options),
           conditional_proc: options[:if],
-          links: options[:links]
+          links: options[:links],
+          lazy_load_data: options[:lazy_load_data]
         )
       end
 

--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -194,7 +194,7 @@ module FastJsonapi
         self.relationships_to_serialize = {} if relationships_to_serialize.nil?
         self.cachable_relationships_to_serialize = {} if cachable_relationships_to_serialize.nil?
         self.uncachable_relationships_to_serialize = {} if uncachable_relationships_to_serialize.nil?
-        
+
         if !relationship.cached
           self.uncachable_relationships_to_serialize[relationship.name] = relationship
         else
@@ -240,7 +240,8 @@ module FastJsonapi
           relationship_type: relationship_type,
           cached: options[:cached],
           polymorphic: fetch_polymorphic_option(options),
-          conditional_proc: options[:if]
+          conditional_proc: options[:if],
+          links: options[:links]
         )
       end
 

--- a/lib/fast_jsonapi/relationship.rb
+++ b/lib/fast_jsonapi/relationship.rb
@@ -30,11 +30,11 @@ module FastJsonapi
       @links = links || {}
     end
 
-    def serialize(record, serialization_params, output_hash, &block)
+    def serialize(record, serialization_params, output_hash)
       if include_relationship?(record, serialization_params)
         empty_case = relationship_type == :has_many ? [] : nil
         output_hash[key] = {
-          data: ids_hash_from_record_and_relationship(record, serialization_params) || empty_case,
+          data: ids_hash_from_record_and_relationship(record, serialization_params) || empty_case
         }
         add_links_hash(record, serialization_params, output_hash) if links.present?
       end

--- a/spec/lib/object_serializer_relationship_links_spec.rb
+++ b/spec/lib/object_serializer_relationship_links_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+describe FastJsonapi::ObjectSerializer do
+  include_context 'movie class'
+
+  context "params option" do
+    let(:hash) { serializer.serializable_hash }
+
+    before(:context) do
+      class MovieSerializer
+        has_many :actors, links: {
+          self:    :actors_relationship_url,
+          related: -> (object, params = {}) {
+            "#{params.has_key?(:secure) ? "https" : "http"}://movies.com/movies/#{object.name.parameterize}/actors/"
+          }
+        }
+      end
+    end
+
+    context "generating links for a serializer relationship" do
+      let(:params) { {  } }
+      let(:options_with_params) { { params: params } }
+      let(:relationship_url) { "http://movies.com/#{movie.id}/relationships/actors" }
+      let(:related_url) { "http://movies.com/movies/#{movie.name.parameterize}/actors/" }
+
+      context "with a single record" do
+        let(:serializer) { MovieSerializer.new(movie, options_with_params) }
+        let(:links) { hash.dig(:data, :relationships, :actors, :links) }
+
+        it "handles relationship links that call a method" do
+          expect(links).to be_present
+          expect(links[:self]).to eq(relationship_url)
+        end
+
+        it "handles relationship links that call a proc" do
+          expect(links).to be_present
+          expect(links[:related]).to eq(related_url)
+        end
+
+        context "with serializer params" do
+          let(:params) { { secure: true } }
+          let(:secure_related_url) { related_url.gsub("http", "https") }
+
+          it "passes the params to the link serializer correctly" do
+            expect(links).to be_present
+            expect(links[:related]).to eq(secure_related_url)
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/spec/lib/object_serializer_relationship_links_spec.rb
+++ b/spec/lib/object_serializer_relationship_links_spec.rb
@@ -25,7 +25,7 @@ describe FastJsonapi::ObjectSerializer do
 
       context "with a single record" do
         let(:serializer) { MovieSerializer.new(movie, options_with_params) }
-        let(:links) { hash.dig(:data, :relationships, :actors, :links) }
+        let(:links) { hash[:data][:relationships][:actors][:links] }
 
         it "handles relationship links that call a method" do
           expect(links).to be_present

--- a/spec/shared/contexts/movie_context.rb
+++ b/spec/shared/contexts/movie_context.rb
@@ -61,6 +61,10 @@ RSpec.shared_context 'movie class' do
       def url
         "http://movies.com/#{id}"
       end
+
+      def actors_relationship_url
+        "#{url}/relationships/actors"
+      end
     end
 
     class Actor


### PR DESCRIPTION
This allows specifying a `:links` option to a has_many/has_one relationship, which means you can specify `self` or `related` links as per the JSON API spec (these are often useful for not loading all associated objects in a single payload)

A few people have chatted about this option or various parts of it in issues (#253, #252, partially in #94).

I'm not 100% if this is the syntax you folks would like, but it's impossible to copy `ActiveModel::Serializers` as the block to the relationship macros is already in use for sparse recordsets. For that reason, I used a `:links` option so the syntax ends up looking like:

```ruby
        has_many :actors, links: {
          self:    :actors_relationship_url,
          related: -> (object, params = {}) {
            "http://movies.com/movies/#{object.name.parameterize}/actors/"
          }
        }
```

This may not be what you folks want, but I thought I'd open a quick PR and then that way we have something to discuss! I'm absolutely fine if y'all want to do this a different way, or you'd like me to change something. Cheers! ✨ 👍 