### PR TITLE
Improve key search for camelized keys

### DIFF
--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -91,7 +91,7 @@ module FastJsonapi
     def deep_symbolize(collection)
       if collection.is_a? Hash
         Hash[collection.map do |k, v|
-          [k.to_sym, deep_symbolize(v)]
+          [self.class.run_key_transform(k), deep_symbolize(v)]
         end]
       elsif collection.is_a? Array
         collection.map { |i| deep_symbolize(i) }

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -41,11 +41,16 @@ module FastJsonapi
       end
 
       def attributes_hash(record, fieldset = nil, params = {})
-        attributes = attributes_to_serialize
-        attributes = attributes.slice(*fieldset) if fieldset.present?
+        attributes = slice_attributes(attributes_to_serialize, fieldset)
         attributes.each_with_object({}) do |(_k, attribute), hash|
           attribute.serialize(record, params, hash)
         end
+      end
+
+      def slice_attributes(attributes, fieldset)
+        return attributes unless fieldset.present?
+        fieldset = fieldset.map { |key| run_key_transform(key) }
+        attributes.slice(*fieldset)
       end
 
       def relationships_hash(record, relationships = nil, fieldset = nil, params = {})


### PR DESCRIPTION
Allow to define a `model_name` and `fieldsets` with their underscore names even if the `set_key_transform` is set to `:camel`.

**Should be valid**:

```ruby
MovieSerializer.set_key_transform :camel
serializer = MovieSerializer.new(movie, { fields: { movie_model_name: [:attribute_name] } })
```

**As well as**:

```ruby
MovieSerializer.set_key_transform :camel
serializer = MovieSerializer.new(movie, { fields: { MovieModelName: [:AttributeName] } })
```