### PR TITLE
add the option "key" in customizable options in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,7 @@ serializer.serializable_hash
 Option | Purpose | Example
 ------------ | ------------- | -------------
 set_type | Type name of Object | ```set_type :movie ```
+key | Key of Object | ```belongs_to :owner, key: :user ```
 set_id | ID of Object | ```set_id :owner_id ```
 cache_options | Hash to enable caching and set cache length | ```cache_options enabled: true, cache_length: 12.hours, race_condition_ttl: 10.seconds```
 id_method_name | Set custom method name to get ID of an object | ```has_many :locations, id_method_name: :place_ids ```


### PR DESCRIPTION
There is an option called "key" that does not exist in the documentation. I had to look in the code to know that it exists. With this option, you can change the json object key.

`belongs_to: owner, key: :user `

```
{
  "data": {
    "id": "3",
    "type": "movie",
    "attributes": {
      "name": "test movie",
      "year": null
    },
    "relationships": {
      "user": {
        "data": {
          "id": "3",
          "type": "owner"
        }
      }
    }
  }
}
```