### PR TITLE
Optional attributes lambda support with 1 or 2 arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ end
 ```
 
 ### Links Per Object
-Links are defined in FastJsonapi using the `link` method. By default, link are read directly from the model property of the same name.In this example, `public_url` is expected to be a property of the object being serialized.
+Links are defined in FastJsonapi using the `link` method. By default, link are read directly from the model property of the same name. In this example, `public_url` is expected to be a property of the object being serialized.
 
 You can configure the method to use on the object for example a link with key `self` will get set to the value returned by a method called `url` on the movie object.
 

--- a/lib/fast_jsonapi/attribute.rb
+++ b/lib/fast_jsonapi/attribute.rb
@@ -20,7 +20,7 @@ module FastJsonapi
 
     def include_attribute?(record, serialization_params)
       if conditional_proc.present?
-        conditional_proc.call(record, serialization_params)
+        conditional_proc.arity.abs == 1 ? conditional_proc.call(record) : conditional_proc.call(record, serialization_params)
       else
         true
       end

--- a/spec/lib/object_serializer_spec.rb
+++ b/spec/lib/object_serializer_spec.rb
@@ -364,6 +364,13 @@ describe FastJsonapi::ObjectSerializer do
       expect(serializable_hash['data']['attributes']['release_year']).to eq movie.release_year
     end
 
+    it 'accepts a lambda taking one argument to make a parameter optional' do
+      movie.release_year = 2001
+      json = MovieOptionalRecordLambdaDataSerializer.new(movie).serialized_json
+      serializable_hash = JSON.parse(json)
+      expect(serializable_hash['data']['attributes']['release_year']).to eq movie.release_year
+    end
+
     it "doesn't return optional attribute when attribute is not included" do
       movie.release_year = 1970
       json = MovieOptionalRecordDataSerializer.new(movie).serialized_json
@@ -376,6 +383,13 @@ describe FastJsonapi::ObjectSerializer do
     it 'returns optional attribute when attribute is included' do
       movie.director = 'steven spielberg'
       json = MovieOptionalParamsDataSerializer.new(movie, { params: { admin: true }}).serialized_json
+      serializable_hash = JSON.parse(json)
+      expect(serializable_hash['data']['attributes']['director']).to eq 'steven spielberg'
+    end
+
+    it 'accepts a lambda taking two arguments to make a parameter optional' do
+      movie.director = 'steven spielberg'
+      json = MovieOptionalParamsLambdaDataSerializer.new(movie, { params: { admin: true }}).serialized_json
       serializable_hash = JSON.parse(json)
       expect(serializable_hash['data']['attributes']['director']).to eq 'steven spielberg'
     end

--- a/spec/shared/contexts/movie_context.rb
+++ b/spec/shared/contexts/movie_context.rb
@@ -297,6 +297,20 @@ RSpec.shared_context 'movie class' do
       attribute :director, if: Proc.new { |record, params| params && params[:admin] == true }
     end
 
+    class MovieOptionalRecordLambdaDataSerializer
+      include FastJsonapi::ObjectSerializer
+      set_type :movie
+      attributes :name
+      attribute :release_year, if: ->(record) { record.release_year >= 2000 }
+    end
+
+    class MovieOptionalParamsLambdaDataSerializer
+      include FastJsonapi::ObjectSerializer
+      set_type :movie
+      attributes :name
+      attribute :director, if: ->(record, params) { params && params[:admin] == true }
+    end
+
     class MovieOptionalRelationshipSerializer
       include FastJsonapi::ObjectSerializer
       set_type :movie


### PR DESCRIPTION
Fixes [issue 303](https://github.com/Netflix/fast_jsonapi/issues/303)