### PR TITLE
Support polymorphic includes

### DIFF
--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -295,8 +295,7 @@ module FastJsonapi
             relationships_to_serialize = klass.relationships_to_serialize || {}
             relationship_to_include = relationships_to_serialize[parsed_include]
             raise ArgumentError, "#{parsed_include} is not specified as a relationship on #{klass.name}" unless relationship_to_include
-            raise NotImplementedError if relationship_to_include.polymorphic.is_a?(Hash)
-            klass = relationship_to_include.serializer.to_s.constantize
+            klass = relationship_to_include.serializer.to_s.constantize unless relationship_to_include.polymorphic.is_a?(Hash)
           end
         end
       end

--- a/lib/fast_jsonapi/relationship.rb
+++ b/lib/fast_jsonapi/relationship.rb
@@ -68,7 +68,7 @@ module FastJsonapi
 
     def id_hash_from_record(record, record_types)
       # memoize the record type within the record_types dictionary, then assigning to record_type:
-      associated_record_type = record_types[record.class] ||= record.class.name.underscore.to_sym
+      associated_record_type = record_types[record.class] ||= record.class.name.demodulize.underscore.to_sym
       id_hash(record.id, associated_record_type)
     end
 

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -119,9 +119,10 @@ module FastJsonapi
             next unless relationships_to_serialize && relationships_to_serialize[item]
             relationship_item = relationships_to_serialize[item]
             next unless relationship_item.include_relationship?(record, params)
-            raise NotImplementedError if relationship_item.polymorphic.is_a?(Hash)
-            record_type = relationship_item.record_type
-            serializer = relationship_item.serializer.to_s.constantize
+            unless relationship_item.polymorphic.is_a?(Hash)
+              record_type = relationship_item.record_type
+              serializer = relationship_item.serializer.to_s.constantize
+            end
             relationship_type = relationship_item.relationship_type
 
             included_objects = relationship_item.fetch_associated_object(record, params)
@@ -129,6 +130,11 @@ module FastJsonapi
             included_objects = [included_objects] unless relationship_type == :has_many
 
             included_objects.each do |inc_obj|
+              if relationship_item.polymorphic.is_a?(Hash)
+                record_type = inc_obj.class.name.demodulize.underscore
+                serializer = self.compute_serializer_name(inc_obj.class.name.demodulize.to_sym).to_s.constantize
+              end
+
               if remaining_items(items)
                 serializer_records = serializer.get_included_records(inc_obj, remaining_items(items), known_included_objects, fieldsets, params)
                 included_records.concat(serializer_records) unless serializer_records.empty?

--- a/spec/lib/object_serializer_spec.rb
+++ b/spec/lib/object_serializer_spec.rb
@@ -278,10 +278,24 @@ describe FastJsonapi::ObjectSerializer do
       end
     end
 
-    it 'polymorphic throws an error that polymorphic is not supported' do
+    it 'polymorphic has_many: returns correct nested includes when serializable_hash is called' do
       options = {}
       options[:include] = [:groupees]
-      expect(-> { GroupSerializer.new([group], options)}).to raise_error(NotImplementedError)
+
+      serializable_hash = GroupSerializer.new([group], options).serializable_hash
+
+      persons_serialized = serializable_hash[:included].find_all { |included| included[:type] == :person }.map { |included| included[:id].to_i }
+      groups_serialized = serializable_hash[:included].find_all { |included| included[:type] == :group }.map { |included| included[:id].to_i }
+
+      persons = group.groupees.find_all { |groupee| groupee.is_a?(Person) }
+      persons.each do |person|
+        expect(persons_serialized).to include(person.id)
+      end
+
+      groups = group.groupees.find_all { |groupee| groupee.is_a?(Group) }
+      groups.each do |group|
+        expect(groups_serialized).to include(group.id)
+      end
     end
   end
 


### PR DESCRIPTION
This PR adds support for polymorphic includes. It should fix issue https://github.com/Netflix/fast_jsonapi/issues/231 (and duplicate issue https://github.com/Netflix/fast_jsonapi/issues/266).

Also, there is some inconsistency regarding what value should be returned for the `type` key when an object belongs to a namespaced class. https://github.com/Netflix/fast_jsonapi/commit/c9aaff8b993eabbfbc50dff138026b0e451df77c aligns the behavior of relationships objects with what's currently being returned for the data objects (no namespace).

Regarding the object's `code` (which has been discussed in previous unfinished PRs), I see no reason why it shouldn't be the same as if the object was serialized outside a polymorphic relationship.