### PR TITLE
Do not use ActiveSupport core extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ end
 ```
 
 ### Links Per Object
-Links are defined in FastJsonapi using the `link` method. By default, link are read directly from the model property of the same name.In this example, `public_url` is expected to be a property of the object being serialized.
+Links are defined in FastJsonapi using the `link` method. By default, link are read directly from the model property of the same name. In this example, `public_url` is expected to be a property of the object being serialized.
 
 You can configure the method to use on the object for example a link with key `self` will get set to the value returned by a method called `url` on the movie object.
 

--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'active_support/core_ext/object'
+require 'active_support/json'
 require 'active_support/concern'
 require 'active_support/inflector'
 require 'fast_jsonapi/attribute'
@@ -65,7 +65,7 @@ module FastJsonapi
     end
 
     def serialized_json
-      self.class.to_json(serializable_hash)
+      ActiveSupport::JSON.encode(serializable_hash)
     end
 
     private


### PR DESCRIPTION
Core extensions often don't play well with many other gems... considering that they only seem to be included for one `to_json` call, it would probably be better to avoid using them altogether and call `ActiveSupport::JSON.encode` directly.