### PR TITLE
Don't share data_links among inherited serializers.

### DIFF
--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -117,7 +117,7 @@ module FastJsonapi
         subclass.transform_method = transform_method
         subclass.cache_length = cache_length
         subclass.race_condition_ttl = race_condition_ttl
-        subclass.data_links = data_links
+        subclass.data_links = data_links.dup
         subclass.cached = cached
         subclass.set_type(subclass.reflected_record_type) if subclass.reflected_record_type
         subclass.meta_to_serialize = meta_to_serialize

--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -117,7 +117,7 @@ module FastJsonapi
         subclass.transform_method = transform_method
         subclass.cache_length = cache_length
         subclass.race_condition_ttl = race_condition_ttl
-        subclass.data_links = data_links.dup
+        subclass.data_links = data_links.dup if data_links.present?
         subclass.cached = cached
         subclass.set_type(subclass.reflected_record_type) if subclass.reflected_record_type
         subclass.meta_to_serialize = meta_to_serialize

--- a/spec/lib/object_serializer_class_methods_spec.rb
+++ b/spec/lib/object_serializer_class_methods_spec.rb
@@ -355,6 +355,22 @@ describe FastJsonapi::ObjectSerializer do
         expect(serializable_hash[:data][:links][:url]).to eq movie.url
       end
     end
+
+    context 'when inheriting from a parent serializer' do
+      before do
+        MovieSerializer.link(:url) do |movie_object|
+          "http://movies.com/#{movie_object.id}"
+        end
+      end
+      subject(:action_serializable_hash) { ActionMovieSerializer.new(movie).serializable_hash }
+      subject(:horror_serializable_hash) { HorrorMovieSerializer.new(movie).serializable_hash }
+
+      let(:url) { "http://movies.com/#{movie.id}" }
+
+      it 'returns the link for the correct sub-class' do
+        expect(action_serializable_hash[:data][:links][:url]).to eq "/action-movie/#{movie.id}"
+      end
+    end
   end
 
   describe '#key_transform' do

--- a/spec/shared/contexts/movie_context.rb
+++ b/spec/shared/contexts/movie_context.rb
@@ -181,6 +181,18 @@ RSpec.shared_context 'movie class' do
       has_one :advertising_campaign
     end
 
+    class GenreMovieSerializer < MovieSerializer
+      link(:something) { '/something/' }
+    end
+
+    class ActionMovieSerializer < GenreMovieSerializer
+      link(:url) { |object| "/action-movie/#{object.id}" }
+    end
+
+    class HorrorMovieSerializer < GenreMovieSerializer
+      link(:url) { |object| "/horror-movie/#{object.id}" }
+    end
+
     class MovieWithoutIdStructSerializer
       include FastJsonapi::ObjectSerializer
       attributes :name, :release_year
@@ -354,6 +366,9 @@ RSpec.shared_context 'movie class' do
 
   after(:context) do
     classes_to_remove = %i[
+      ActionMovieSerializer
+      GenreMovieSerializer
+      HorrorMovieSerializer
       Movie
       MovieSerializer
       Actor


### PR DESCRIPTION
As demonstrated by the included specs, if serializers share a common ancestor that defines data_links, they end up sharing the same data_links object, overwriting each other, so that the last-evaluated sub-class overwrites the others' data_links values.