### PR TITLE
Allow block for id customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ Option | Purpose | Example
 ------------ | ------------- | -------------
 set_type | Type name of Object | ```set_type :movie ```
 key | Key of Object | ```belongs_to :owner, key: :user ```
-set_id | ID of Object | ```set_id :owner_id ```
+set_id | ID of Object | ```set_id :owner_id ``` or ```set_id { |record| "#{record.name.downcase}-#{record.id}" }```
 cache_options | Hash to enable caching and set cache length | ```cache_options enabled: true, cache_length: 12.hours, race_condition_ttl: 10.seconds```
 id_method_name | Set custom method name to get ID of an object | ```has_many :locations, id_method_name: :place_ids ```
 object_method_name | Set custom method name to get related objects | ```has_many :locations, object_method_name: :places ```

--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -167,8 +167,8 @@ module FastJsonapi
         self.record_type = run_key_transform(type_name)
       end
 
-      def set_id(id_name)
-        self.record_id = id_name
+      def set_id(id_name = nil, &block)
+        self.record_id = block || id_name
       end
 
       def cache_options(cache_options)

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -86,9 +86,10 @@ module FastJsonapi
       end
 
       def id_from_record(record)
-         return record.send(record_id) if record_id
-         raise MandatoryField, 'id is a mandatory field in the jsonapi spec' unless record.respond_to?(:id)
-         record.id
+        return record_id.call(record) if record_id.is_a?(Proc)
+        return record.send(record_id) if record_id
+        raise MandatoryField, 'id is a mandatory field in the jsonapi spec' unless record.respond_to?(:id)
+        record.id
       end
 
       # Override #to_json for alternative implementation

--- a/spec/lib/object_serializer_class_methods_spec.rb
+++ b/spec/lib/object_serializer_class_methods_spec.rb
@@ -195,28 +195,57 @@ describe FastJsonapi::ObjectSerializer do
   describe '#set_id' do
     subject(:serializable_hash) { MovieSerializer.new(resource).serializable_hash }
 
-    before do
-      MovieSerializer.set_id :owner_id
-    end
+    context 'method name' do
+      before do
+        MovieSerializer.set_id :owner_id
+      end
 
-    after do
-      MovieSerializer.set_id nil
-    end
+      after do
+        MovieSerializer.set_id nil
+      end
 
-    context 'when one record is given' do
-      let(:resource) { movie }
+      context 'when one record is given' do
+        let(:resource) { movie }
 
-      it 'returns correct hash which id equals owner_id' do
-        expect(serializable_hash[:data][:id].to_i).to eq movie.owner_id
+        it 'returns correct hash which id equals owner_id' do
+          expect(serializable_hash[:data][:id].to_i).to eq movie.owner_id
+        end
+      end
+
+      context 'when an array of records is given' do
+        let(:resource) { [movie, movie] }
+
+        it 'returns correct hash which id equals owner_id' do
+          expect(serializable_hash[:data][0][:id].to_i).to eq movie.owner_id
+          expect(serializable_hash[:data][1][:id].to_i).to eq movie.owner_id
+        end
       end
     end
 
-    context 'when an array of records is given' do
-      let(:resource) { [movie, movie] }
+    context 'with block' do
+      before do
+        MovieSerializer.set_id { |record| "movie-#{record.owner_id}" }
+      end
 
-      it 'returns correct hash which id equals owner_id' do
-        expect(serializable_hash[:data][0][:id].to_i).to eq movie.owner_id
-        expect(serializable_hash[:data][1][:id].to_i).to eq movie.owner_id
+      after do
+        MovieSerializer.set_id nil
+      end
+
+      context 'when one record is given' do
+        let(:resource) { movie }
+
+        it 'returns correct hash which id equals movie-id' do
+          expect(serializable_hash[:data][:id]).to eq "movie-#{movie.owner_id}"
+        end
+      end
+
+      context 'when an array of records is given' do
+        let(:resource) { [movie, movie] }
+
+        it 'returns correct hash which id equals movie-id' do
+          expect(serializable_hash[:data][0][:id]).to eq "movie-#{movie.owner_id}"
+          expect(serializable_hash[:data][1][:id]).to eq "movie-#{movie.owner_id}"
+        end
       end
     end
   end


### PR DESCRIPTION
Allow an ID of object to be customized directly on the serializer by
passing a block to `set_id` as opposed to only through a model property.

We already allow for attributes that do not have a model property of the
same name to be customized directly on the serializer using a block.

Closes #315