### PR TITLE
Allow fieldsets to specify no attributes/relationships

### DIFF
--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -44,6 +44,8 @@ module FastJsonapi
       def attributes_hash(record, fieldset = nil, params = {})
         attributes = attributes_to_serialize
         attributes = attributes.slice(*fieldset) if fieldset.present?
+        attributes = {} if fieldset == []
+
         attributes.each_with_object({}) do |(_k, attribute), hash|
           attribute.serialize(record, params, hash)
         end
@@ -52,6 +54,7 @@ module FastJsonapi
       def relationships_hash(record, relationships = nil, fieldset = nil, params = {})
         relationships = relationships_to_serialize if relationships.nil?
         relationships = relationships.slice(*fieldset) if fieldset.present?
+        relationships = {} if fieldset == []
 
         relationships.each_with_object({}) do |(_k, relationship), hash|
           relationship.serialize(record, params, hash)

--- a/spec/lib/object_serializer_fields_spec.rb
+++ b/spec/lib/object_serializer_fields_spec.rb
@@ -22,6 +22,18 @@ describe FastJsonapi::ObjectSerializer do
     expect(hash[:data][:relationships].keys.sort).to eq %i[actors advertising_campaign]
   end
 
+  it 'returns no fields when none are specified' do
+    hash = MovieSerializer.new(movie, fields: { movie: [] }).serializable_hash
+
+    expect(hash[:data][:attributes].keys).to eq []
+  end
+
+  it 'returns no relationships when none are specified' do
+    hash = MovieSerializer.new(movie, fields: { movie: [] }).serializable_hash
+
+    expect(hash[:data][:relationships].keys).to eq []
+  end
+
   it 'only returns specified fields for included relationships' do
     hash = MovieSerializer.new(movie, fields: fields, include: %i[actors]).serializable_hash
 
@@ -44,5 +56,26 @@ describe FastJsonapi::ObjectSerializer do
     hash = MovieSerializer.new(movie, fields: fields, include: %i[actors advertising_campaign]).serializable_hash
 
     expect(hash[:included][3][:relationships].keys.sort).to eq %i[movie]
+  end
+
+  context 'with no included fields specified' do
+    let(:fields) do
+      {
+        movie: %i[name actors advertising_campaign],
+        actor: []
+      }
+    end
+
+    it 'returns no fields for included relationships when none are specified' do
+      hash = MovieSerializer.new(movie, fields: fields, include: %i[actors advertising_campaign]).serializable_hash
+
+      expect(hash[:included][2][:attributes].keys).to eq []
+    end
+
+    it 'returns no relationships when none are specified' do
+      hash = MovieSerializer.new(movie, fields: fields, include: %i[actors advertising_campaign]).serializable_hash
+
+      expect(hash[:included][2][:relationships].keys).to eq []
+    end
   end
 end


### PR DESCRIPTION
Users should be allowed to specify no fields/relationships. 

Conceptually it is the difference between `/acceptance/resources/1` and `/acceptance/resources/1?fields[resource]=`. 

The corresponding payload would be
```
data: {
  type: "resource",
  id: 1
}
```
This is a useful feature for APIs when loading a large number of resources and wanting to minimize the size of the payload. 