### PR TITLE
require AS core extension for time

### DIFF
--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -3,6 +3,7 @@
 require 'active_support/json'
 require 'active_support/concern'
 require 'active_support/inflector'
+require 'active_support/core_ext/numeric/time'
 require 'fast_jsonapi/attribute'
 require 'fast_jsonapi/relationship'
 require 'fast_jsonapi/link'


### PR DESCRIPTION
`5.minutes` was failing when i ran the performance spec