### PR TITLE
Fix params not being hash by default

### DIFF
--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'active_support/time'
 require 'active_support/json'
 require 'active_support/concern'
 require 'active_support/inflector'
@@ -72,6 +73,7 @@ module FastJsonapi
 
     def process_options(options)
       @fieldsets = deep_symbolize(options[:fields].presence || {})
+      @params = {}
 
       return if options.blank?
 

--- a/spec/lib/object_serializer_attribute_param_spec.rb
+++ b/spec/lib/object_serializer_attribute_param_spec.rb
@@ -15,7 +15,7 @@ describe FastJsonapi::ObjectSerializer do
 
       class MovieSerializer
         attribute :viewed do |movie, params|
-          params ? movie.viewed?(params[:user]) : false
+          params[:user] ? movie.viewed?(params[:user]) : false
         end
 
         attribute :no_param_attribute do |movie|

--- a/spec/lib/object_serializer_spec.rb
+++ b/spec/lib/object_serializer_spec.rb
@@ -504,4 +504,10 @@ describe FastJsonapi::ObjectSerializer do
       end
     end
   end
+
+  context 'when attribute contents are determined by params data' do
+    it 'does not throw an error with no params are passed' do
+      expect { MovieOptionalAttributeContentsWithParamsSerializer.new(movie).serialized_json }.not_to raise_error
+    end
+  end
 end

--- a/spec/shared/contexts/movie_context.rb
+++ b/spec/shared/contexts/movie_context.rb
@@ -240,8 +240,8 @@ RSpec.shared_context 'movie class' do
       include FastJsonapi::ObjectSerializer
       attributes :id, :title
       attribute :year, if: Proc.new { |record, params|
-        params[:include_award_year].present? ? 
-          params[:include_award_year] : 
+        params[:include_award_year].present? ?
+          params[:include_award_year] :
           false
       }
       belongs_to :actor
@@ -313,7 +313,7 @@ RSpec.shared_context 'movie class' do
       include FastJsonapi::ObjectSerializer
       set_type :movie
       attributes :name
-      attribute :director, if: Proc.new { |record, params| params && params[:admin] == true }
+      attribute :director, if: Proc.new { |record, params| params[:admin] == true }
     end
 
     class MovieOptionalRelationshipSerializer
@@ -327,7 +327,19 @@ RSpec.shared_context 'movie class' do
       include FastJsonapi::ObjectSerializer
       set_type :movie
       attributes :name
-      belongs_to :owner, record_type: :user, if: Proc.new { |record, params| params && params[:admin] == true }
+      belongs_to :owner, record_type: :user, if: Proc.new { |record, params| params[:admin] == true }
+    end
+
+    class MovieOptionalAttributeContentsWithParamsSerializer
+      include FastJsonapi::ObjectSerializer
+      set_type :movie
+      attributes :name
+      attribute :director do |record, params|
+        data = {}
+        data[:first_name] = 'steven'
+        data[:last_name] = 'spielberg' if params[:admin]
+        data
+      end
     end
   end
 


### PR DESCRIPTION
This fixes a minor thing that has been nagging at me for a while: I always had to do `params && params[:foo]` in an attribute block because params is undefined unless the controller explicitly passes it. I think we should be able to expect params to always be defined.

The bug occurs when no options are passed and the early return `return if options.blank?` prevents params being set to `{}` by default.