### PR TITLE
Preset Sparse Fieldsets

### DIFF
--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -89,6 +89,8 @@ module FastJsonapi
         @includes = options[:include].delete_if(&:blank?).map(&:to_sym)
         self.class.validate_includes!(@includes)
       end
+
+      @fieldsets[self.class.record_type.to_sym] = self.class.fields_presets[options[:preset_fields]] if options[:preset_fields]
     end
 
     def deep_symbolize(collection)
@@ -197,6 +199,11 @@ module FastJsonapi
       end
 
       alias_method :attribute, :attributes
+
+      def preset_fields(preset_name, *fields)
+        self.fields_presets ||= {}
+        self.fields_presets[preset_name] = fields
+      end
 
       def add_relationship(relationship)
         self.relationships_to_serialize = {} if relationships_to_serialize.nil?

--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -90,7 +90,10 @@ module FastJsonapi
         self.class.validate_includes!(@includes)
       end
 
-      @fieldsets[self.class.record_type.to_sym] = self.class.fields_presets[options[:preset_fields]] if options[:preset_fields]
+      if options[:preset_fields] && self.class.fields_presets
+        preset = self.class.fields_presets[options[:preset_fields]]
+        @fieldsets[self.class.record_type.to_sym] = preset if preset
+      end
     end
 
     def deep_symbolize(collection)

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -22,7 +22,8 @@ module FastJsonapi
                       :race_condition_ttl,
                       :cached,
                       :data_links,
-                      :meta_to_serialize
+                      :meta_to_serialize,
+                      :fields_presets
       end
     end
 

--- a/spec/lib/object_serializer_fields_spec.rb
+++ b/spec/lib/object_serializer_fields_spec.rb
@@ -58,7 +58,7 @@ describe FastJsonapi::ObjectSerializer do
       m
     end
 
-    class MovieSerializer
+    class MovieWithPresetSerializer
       include FastJsonapi::ObjectSerializer
       set_type :movie
       # director attr is not mentioned intentionally
@@ -73,8 +73,8 @@ describe FastJsonapi::ObjectSerializer do
       preset_fields :summary, :name, :release_year, :movie_type
     end
 
-    it 'include only location' do
-      data = MovieSerializer.new(movie, preset_fields: :summary).serializable_hash[:data]
+    it 'include only summary preset' do
+      data = MovieWithPresetSerializer.new(movie, preset_fields: :summary).serializable_hash[:data]
       expect(data[:attributes]).to eq name: 'test movie', release_year: 2018
       expect(data[:relationships].keys).to eq [:movie_type]
     end


### PR DESCRIPTION
I was thinking about a new feature base on the _Sparse Fieldsets_ option.

It consist to declared some presets of fields in the _Serializer_ class so it can be easily reuse, instead of passing an option hash or declaring multiple serializer for each case (i.e. `AccountSerializer`, `MinimalAccountSerializer`)

There is an example of use case.

```ruby
class AccountSerializer
  include FastJsonapi::ObjectSerializer

  attributes :first_name,
             :last_name,
             :birthday,
             :email,
             :picture_url

  field_preset :minimal, :first_name, :last_name
  field_preset :profile, :first_name, :last_name, :birthday, :picture_url
end
```

```ruby
# GET /me/friends
AccountSerializer.new(auth_account, { fields: { account: [:first_name, :last_name] } }) # using Sparse Fieldsets
# OR
AccountSerializer.new auth_account.friends, field_preset: :minimal # using Field preset

# GET /me/profile
AccountSerializer.new(auth_account, { fields: { account: [ :first_name, :last_name, :birthday, :picture_url] } }) # using Sparse Fieldsets
# OR
AccountSerializer.new auth_account.friends, field_preset: :profile # using Field preset
```
