### PR TITLE
Use #each instead of #size for determining is_collection?

### DIFF
--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -104,9 +104,7 @@ module FastJsonapi
     end
 
     def is_collection?(resource, force_is_collection = nil)
-      return force_is_collection unless force_is_collection.nil?
-
-      resource.respond_to?(:size) && !resource.respond_to?(:each_pair)
+      force_is_collection || (resource.respond_to?(:each) && !resource.respond_to?(:each_pair))
     end
 
     class_methods do

--- a/spec/shared/contexts/movie_context.rb
+++ b/spec/shared/contexts/movie_context.rb
@@ -65,6 +65,10 @@ RSpec.shared_context 'movie class' do
       def actors_relationship_url
         "#{url}/relationships/actors"
       end
+
+      def size
+        42
+      end
     end
 
     class Actor


### PR DESCRIPTION
Ran into this issue where a few of our models have a `size` attribute. While `resource.responds_to?(:each)` presents a similar problem, I feel that classes that implement `each` are intentionally acting as a collection. 