### PR TITLE
Validate all include options

### DIFF
--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -299,7 +299,7 @@ module FastJsonapi
       def validate_includes!(includes)
         return if includes.blank?
 
-        includes.detect do |include_item|
+        includes.each do |include_item|
           klass = self
           parse_include_item(include_item).each do |parsed_include|
             relationships_to_serialize = klass.relationships_to_serialize || {}

--- a/spec/lib/object_serializer_spec.rb
+++ b/spec/lib/object_serializer_spec.rb
@@ -142,9 +142,22 @@ describe FastJsonapi::ObjectSerializer do
       expect { MovieSerializer.new([movie, movie], options).serializable_hash }.to raise_error(ArgumentError)
     end
 
+    it 'returns errors when serializing with non-existent and existent includes keys' do
+      options = {}
+      options[:meta] = { total: 2 }
+      options[:include] = [:actors, :blah_blah]
+      expect { MovieSerializer.new([movie, movie], options).serializable_hash }.to raise_error(ArgumentError)
+    end
+
     it 'does not throw an error with non-empty string array includes key' do
       options = {}
       options[:include] = ['actors']
+      expect { MovieSerializer.new(movie, options) }.not_to raise_error
+    end
+
+    it 'does not throw an error with non-empty string array includes keys' do
+      options = {}
+      options[:include] = ['actors', 'owner']
       expect { MovieSerializer.new(movie, options) }.not_to raise_error
     end
 


### PR DESCRIPTION
Per the spec, https://jsonapi.org/format/#fetching-includes

`If a server is unable to identify a relationship path or does not support inclusion of resources from a path, it MUST respond with 400 Bad Request.`

Currently the library is only checking the first instance due to using detect which stops processing after the block returns true once.

Without this change, the new test in [spec/lib/object_serializer_spec.rb:145](https://github.com/danielduke/fast_jsonapi/blob/validate-all-include-options/spec/lib/object_serializer_spec.rb#L145-L150) fails.