### PR TITLE
Use FastJsonapi::MultiToJson#to_json

### DIFF
--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'active_support/time'
-require 'active_support/json'
 require 'active_support/concern'
 require 'active_support/inflector'
 require 'active_support/core_ext/numeric/time'
@@ -67,7 +66,7 @@ module FastJsonapi
     end
 
     def serialized_json
-      ActiveSupport::JSON.encode(serializable_hash)
+      self.class.to_json(serializable_hash)
     end
 
     private


### PR DESCRIPTION
A few days ago, I updated the version of `fast_jsonapi` from `1.3` to `1.5`, and I noticed that the performance was decreasing.

As a result of measurement, `ActiveSupport::JSON.encode` is always called by [this change](https://github.com/Netflix/fast_jsonapi/pull/312), and it seemed to be one cause that `FastJsonapi::MultiToJson#to_json` was not called.

I think that it is better to return this. 

refs.

- https://github.com/Netflix/fast_jsonapi/pull/312/files#diff-34088120ad9556cc6578b0c51b38c723
- https://github.com/Netflix/fast_jsonapi/blob/release-1.5/lib/fast_jsonapi/serialization_core.rb#L96-L98
- https://github.com/Netflix/fast_jsonapi/blob/release-1.5/lib/fast_jsonapi/multi_to_json.rb#L54-L79