### PR TITLE
pass array of unique movies to serializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,17 @@ movie.actor_ids = [1, 2, 3]
 movie.owner_id = 3
 movie.movie_type_id = 1
 movie
+
+movies =
+  2.times.map do |i|
+    m = Movie.new
+    m.id = i + 1
+    m.name = "test movie #{i}"
+    m.actor_ids = [1, 2, 3]
+    m.owner_id = 3
+    m.movie_type_id = 1
+    m
+  end
 ```
 
 ### Object Serialization
@@ -311,7 +322,7 @@ options[:links] = {
   prev: '...'
 }
 hash = MovieSerializer.new(movies, options).serializable_hash
-json_string = MovieSerializer.new([movie, movie], options).serialized_json
+json_string = MovieSerializer.new(movies, options).serialized_json
 ```
 
 #### Control Over Collection Serialization

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ options[:links] = {
   prev: '...'
 }
 options[:include] = [:actors, :'actors.agency', :'actors.agency.state']
-MovieSerializer.new([movie, movie], options).serialized_json
+MovieSerializer.new(movies, options).serialized_json
 ```
 
 ### Collection Serialization
@@ -310,7 +310,7 @@ options[:links] = {
   next: '...',
   prev: '...'
 }
-hash = MovieSerializer.new([movie, movie], options).serializable_hash
+hash = MovieSerializer.new(movies, options).serializable_hash
 json_string = MovieSerializer.new([movie, movie], options).serialized_json
 ```
 

--- a/spec/lib/instrumentation/as_notifications_negative_spec.rb
+++ b/spec/lib/instrumentation/as_notifications_negative_spec.rb
@@ -10,7 +10,8 @@ describe FastJsonapi::ObjectSerializer do
       options[:meta] = { total: 2 }
       options[:include] = [:actors]
 
-      @serializer = MovieSerializer.new([movie, movie], options)
+      movies = build_movies(2)
+      @serializer = MovieSerializer.new(movies, options)
     end
 
     context 'serializable_hash' do

--- a/spec/lib/instrumentation/as_notifications_spec.rb
+++ b/spec/lib/instrumentation/as_notifications_spec.rb
@@ -24,7 +24,8 @@ describe FastJsonapi::ObjectSerializer do
       options[:meta] = { total: 2 }
       options[:include] = [:actors]
 
-      @serializer = MovieSerializer.new([movie, movie], options)
+      movies = build_movies(2)
+      @serializer = MovieSerializer.new(movies, options)
     end
 
     context 'serializable_hash' do

--- a/spec/lib/object_serializer_caching_spec.rb
+++ b/spec/lib/object_serializer_caching_spec.rb
@@ -16,7 +16,8 @@ describe FastJsonapi::ObjectSerializer do
       options[:links] = { self: 'self' }
 
       options[:include] = [:actors]
-      serializable_hash = CachingMovieSerializer.new([movie, movie], options).serializable_hash
+      movies = build_movies(2)
+      serializable_hash = CachingMovieSerializer.new(movies, options).serializable_hash
 
       expect(serializable_hash[:data].length).to eq 2
       expect(serializable_hash[:data][0][:relationships].length).to eq 3

--- a/spec/lib/object_serializer_class_methods_spec.rb
+++ b/spec/lib/object_serializer_class_methods_spec.rb
@@ -213,7 +213,7 @@ describe FastJsonapi::ObjectSerializer do
       end
 
       context 'when an array of records is given' do
-        let(:resource) { [movie, movie] }
+        let(:resource) { build_movies(2) }
 
         it 'returns correct hash which id equals owner_id' do
           expect(serializable_hash[:data][0][:id].to_i).to eq movie.owner_id
@@ -240,7 +240,7 @@ describe FastJsonapi::ObjectSerializer do
       end
 
       context 'when an array of records is given' do
-        let(:resource) { [movie, movie] }
+        let(:resource) { build_movies(2) }
 
         it 'returns correct hash which id equals movie-id' do
           expect(serializable_hash[:data][0][:id]).to eq "movie-#{movie.owner_id}"
@@ -403,7 +403,7 @@ describe FastJsonapi::ObjectSerializer do
   end
 
   describe '#key_transform' do
-    subject(:hash) { movie_serializer_class.new([movie, movie], include: [:movie_type]).serializable_hash }
+    subject(:hash) { movie_serializer_class.new(build_movies(2), include: [:movie_type]).serializable_hash }
 
     let(:movie_serializer_class) { "#{key_transform}_movie_serializer".classify.constantize }
 

--- a/spec/lib/object_serializer_spec.rb
+++ b/spec/lib/object_serializer_spec.rb
@@ -4,13 +4,14 @@ describe FastJsonapi::ObjectSerializer do
   include_context 'movie class'
   include_context 'group class'
 
+  let(:movies) { build_movies(2) }
+
   context 'when testing instance methods of object serializer' do
     it 'returns correct hash when serializable_hash is called' do
       options = {}
       options[:meta] = { total: 2 }
       options[:links] = { self: 'self' }
       options[:include] = [:actors]
-      movies = build_movies(2)
       serializable_hash = MovieSerializer.new(movies, options).serializable_hash
 
       expect(serializable_hash[:data].length).to eq 2
@@ -59,7 +60,6 @@ describe FastJsonapi::ObjectSerializer do
     it 'returns correct number of records when serialized_json is called for an array' do
       options = {}
       options[:meta] = { total: 2 }
-      movies = build_movies(2)
       json = MovieSerializer.new(movies, options).serialized_json
       serializable_hash = JSON.parse(json)
       expect(serializable_hash['data'].length).to eq 2
@@ -126,7 +126,6 @@ describe FastJsonapi::ObjectSerializer do
       end
 
       it 'returns multiple records' do
-        movies = build_movies(2)
         json_hash = MovieSerializer.new(movies).as_json
         expect(json_hash['data'].length).to eq 2
       end
@@ -142,7 +141,6 @@ describe FastJsonapi::ObjectSerializer do
       options = {}
       options[:meta] = { total: 2 }
       options[:include] = [:blah_blah]
-      movies = build_movies(2)
       expect { MovieSerializer.new(movies, options).serializable_hash }.to raise_error(ArgumentError)
     end
 
@@ -156,7 +154,6 @@ describe FastJsonapi::ObjectSerializer do
       options = {}
       options[:meta] = { total: 2 }
       options[:include] = ['']
-      movies = build_movies(2)
       expect(MovieSerializer.new(movies, options).serializable_hash.keys).to eq [:data, :meta]
       options[:include] = [nil]
       expect(MovieSerializer.new(movies, options).serializable_hash.keys).to eq [:data, :meta]

--- a/spec/lib/object_serializer_spec.rb
+++ b/spec/lib/object_serializer_spec.rb
@@ -10,7 +10,8 @@ describe FastJsonapi::ObjectSerializer do
       options[:meta] = { total: 2 }
       options[:links] = { self: 'self' }
       options[:include] = [:actors]
-      serializable_hash = MovieSerializer.new([movie, movie], options).serializable_hash
+      movies = build_movies(2)
+      serializable_hash = MovieSerializer.new(movies, options).serializable_hash
 
       expect(serializable_hash[:data].length).to eq 2
       expect(serializable_hash[:data][0][:relationships].length).to eq 4
@@ -58,7 +59,8 @@ describe FastJsonapi::ObjectSerializer do
     it 'returns correct number of records when serialized_json is called for an array' do
       options = {}
       options[:meta] = { total: 2 }
-      json = MovieSerializer.new([movie, movie], options).serialized_json
+      movies = build_movies(2)
+      json = MovieSerializer.new(movies, options).serialized_json
       serializable_hash = JSON.parse(json)
       expect(serializable_hash['data'].length).to eq 2
       expect(serializable_hash['meta']).to be_instance_of(Hash)
@@ -124,7 +126,8 @@ describe FastJsonapi::ObjectSerializer do
       end
 
       it 'returns multiple records' do
-        json_hash = MovieSerializer.new([movie, movie]).as_json
+        movies = build_movies(2)
+        json_hash = MovieSerializer.new(movies).as_json
         expect(json_hash['data'].length).to eq 2
       end
 
@@ -139,7 +142,8 @@ describe FastJsonapi::ObjectSerializer do
       options = {}
       options[:meta] = { total: 2 }
       options[:include] = [:blah_blah]
-      expect { MovieSerializer.new([movie, movie], options).serializable_hash }.to raise_error(ArgumentError)
+      movies = build_movies(2)
+      expect { MovieSerializer.new(movies, options).serializable_hash }.to raise_error(ArgumentError)
     end
 
     it 'does not throw an error with non-empty string array includes key' do
@@ -152,9 +156,10 @@ describe FastJsonapi::ObjectSerializer do
       options = {}
       options[:meta] = { total: 2 }
       options[:include] = ['']
-      expect(MovieSerializer.new([movie, movie], options).serializable_hash.keys).to eq [:data, :meta]
+      movies = build_movies(2)
+      expect(MovieSerializer.new(movies, options).serializable_hash.keys).to eq [:data, :meta]
       options[:include] = [nil]
-      expect(MovieSerializer.new([movie, movie], options).serializable_hash.keys).to eq [:data, :meta]
+      expect(MovieSerializer.new(movies, options).serializable_hash.keys).to eq [:data, :meta]
     end
   end
 


### PR DESCRIPTION
According to JSON API document, `id` should be unique.
https://jsonapi.org/format/#document-resource-objects

`id` of movie generated by `let(:movie)` is always same.
https://github.com/Netflix/fast_jsonapi/blob/master/spec/shared/contexts/movie_context.rb#L438

So I replace array passed to serializer `[movies, movies]` to `build_movies(2)`

before: 
```
MovieSerializer.new([movie, movie], options)
```
after:
```
movies = build_movies(2)
MovieSerializer.new(movies, options)
```
