### PR TITLE
Add params to set_id block arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,12 +354,18 @@ related to a current authenticated user. The `options[:params]` value covers the
 cases by allowing you to pass in a hash of additional parameters necessary for
 your use case.
 
-Leveraging the new params is easy, when you define a custom attribute or relationship with a
-block you opt-in to using params by adding it as a block parameter.
+Leveraging the new params is easy, when you define a custom id, attribute or
+relationship with a block you opt-in to using params by adding it as a block
+parameter.
 
 ```ruby
 class MovieSerializer
   include FastJsonapi::ObjectSerializer
+
+  set_id do |movie, params|
+    # in here, params is a hash containing the `:admin` key
+    params[:admin] ? movie.owner_id : "movie-#{movie.id}"
+  end
 
   attributes :name, :year
   attribute :can_view_early do |movie, params|
@@ -450,7 +456,7 @@ Option | Purpose | Example
 ------------ | ------------- | -------------
 set_type | Type name of Object | ```set_type :movie ```
 key | Key of Object | ```belongs_to :owner, key: :user ```
-set_id | ID of Object | ```set_id :owner_id ``` or ```set_id { |record| "#{record.name.downcase}-#{record.id}" }```
+set_id | ID of Object | ```set_id :owner_id ``` or ```set_id { |record, params| params[:admin] ? record.id : "#{record.name.downcase}-#{record.id}" }```
 cache_options | Hash to enable caching and set cache length | ```cache_options enabled: true, cache_length: 12.hours, race_condition_ttl: 10.seconds```
 id_method_name | Set custom method name to get ID of an object (If block is provided for the relationship, `id_method_name` is invoked on the return value of the block instead of the resource object) | ```has_many :locations, id_method_name: :place_ids ```
 object_method_name | Set custom method name to get related objects | ```has_many :locations, object_method_name: :places ```

--- a/spec/lib/object_serializer_class_methods_spec.rb
+++ b/spec/lib/object_serializer_class_methods_spec.rb
@@ -193,7 +193,10 @@ describe FastJsonapi::ObjectSerializer do
   end
 
   describe '#set_id' do
-    subject(:serializable_hash) { MovieSerializer.new(resource).serializable_hash }
+    let(:params) { {} }
+    subject(:serializable_hash) do
+      MovieSerializer.new(resource, { params: params }).serializable_hash
+    end
 
     context 'method name' do
       before do
@@ -223,8 +226,12 @@ describe FastJsonapi::ObjectSerializer do
     end
 
     context 'with block' do
+      let(:params) { { prefix: 'movie' } }
+
       before do
-        MovieSerializer.set_id { |record| "movie-#{record.owner_id}" }
+        MovieSerializer.set_id do |record, params|
+          "#{params[:prefix]}-#{record.owner_id}"
+        end
       end
 
       after do


### PR DESCRIPTION
Pull request #331 added a block to the ObjectSerializer.set_id class
method, which allows passing a block to the set_id method. Currently
this block takes only one argument `record`:

```
set_id do |record|
  "#{record.name.downcase}-#{record.id}"
end
```

This PR adds another argument `params` to the block:

```
set id do |record, params|
  params[:admin] ?  record.id : "#{record.name.downcase}-#{record.id}"
end
```

This customization can be useful in situation where we serve different
clients that may need different IDs. One nice side effect is also that
the `set_id` method has the same method signature as the `attribute`
method.

This PR fixes #373 