### PR TITLE
Highlight that this is for JSON:API spec only

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 A lightning fast [JSON:API](http://jsonapi.org/) serializer for Ruby Objects.
 
+Note: this gem deals only with implementing the JSON:API spec. If your API
+responses are not formatted according to the JSON:API spec, this library will
+not work for you.
+
 # Performance Comparison
 
 We compare serialization times with Active Model Serializer as part of RSpec performance tests included on this library. We want to ensure that with every change on this library, serialization time is at least `25 times` faster than Active Model Serializers on up to current benchmark of 1000 records. Please read the [performance document](https://github.com/Netflix/fast_jsonapi/blob/master/performance_methodology.md) for any questions related to methodology.


### PR DESCRIPTION
* The link was already there but I skipped over it on my first read.
This update makes the fact more prominent.
* I was testing to see if we wanted to move from AM Serializers to
fast_jsonapi but our API is not written according to the JSON:API spec
so, after converting one serializer over, I learned that this would not work for me.
* This update might save someone in my position the ~30 mins or so it
takes to bundle and write a serializer in the future. :)