### PR TITLE
allow passing proc for relationships with id_method_name

### DIFF
--- a/lib/fast_jsonapi/relationship.rb
+++ b/lib/fast_jsonapi/relationship.rb
@@ -47,8 +47,11 @@ module FastJsonapi
     end
 
     def fetch_associated_object(record, params)
-      return object_block.call(record, params) unless object_block.nil?
-      record.send(object_method_name)
+      if object_block.present?
+        object_block.arity.abs == 1 ? object_block.call(record) : object_block.call(record, params)
+      else
+        record.send(object_method_name)
+      end
     end
 
     def include_relationship?(record, serialization_params)
@@ -96,7 +99,7 @@ module FastJsonapi
 
     def fetch_id(record, params)
       if object_block.present?
-        object = object_block.call(record, params)
+        object = object_block.arity.abs == 1 ? object_block.call(record) : object_block.call(record, params)
         return object.map { |item| item.public_send(id_method_name) } if object.respond_to? :map
         return object.try(id_method_name)
       end

--- a/spec/lib/object_serializer_class_methods_spec.rb
+++ b/spec/lib/object_serializer_class_methods_spec.rb
@@ -102,8 +102,31 @@ describe FastJsonapi::ObjectSerializer do
       subject(:hash) { MovieSerializer.new(movie).serializable_hash }
 
       it 'returns correct hash where id is obtained from the method specified via `id_method_name`' do
-        expected_award_data = movie.actors.map(&:awards).flatten.map do |actor|
-          { id: actor.imdb_award_id.to_s, type: actor.class.name.downcase.to_sym }
+        expected_award_data = movie.actors.map(&:awards).flatten.map do |award|
+          { id: award.imdb_award_id.to_s, type: award.class.name.downcase.to_sym }
+        end
+        serialized_award_data = hash[:data][:relationships][:awards][:data]
+
+        expect(serialized_award_data).to eq(expected_award_data)
+      end
+    end
+  end
+
+  describe '#has_many with proc and id_method_name' do
+    before do
+      ActorSerializer.has_many(:awards, id_method_name: :imdb_award_id, &:awards)
+    end
+
+    after do
+      ActorSerializer.relationships_to_serialize.delete(:awards)
+    end
+
+    context 'awards is not included' do
+      subject(:hash) { ActorSerializer.new(actor).serializable_hash }
+
+      it 'returns correct hash where id is obtained from the method specified via `id_method_name`' do
+        expected_award_data = actor.awards.flatten.map do |award|
+          { id: award.imdb_award_id.to_s, type: award.class.name.downcase.to_sym }
         end
         serialized_award_data = hash[:data][:relationships][:awards][:data]
 


### PR DESCRIPTION
When using `id_method_name` in relationship, we can allow passing simple proc object to relationship in place of a block.
For example: 
```
 class User
  include FastJsonapi::ObjectSerializer

  set_id :uuid
  set_key_transform :dash
  set_type :users 
  attributes :name, :email 

 # To support this (currently results into error)
  belongs_to :organization, record_type: :organizations, id_method_name: :uuid, &:organization


 # Instead of this
 # belongs_to :organization, record_type: :organizations, id_method_name: :uuid do |object|
 #   object.organization
 # end
end
```