### PR TITLE
Handle a heterogeneous collection via serializers option

### DIFF
--- a/spec/lib/object_serializer_heterogeneous_spec.rb
+++ b/spec/lib/object_serializer_heterogeneous_spec.rb
@@ -1,0 +1,114 @@
+require 'spec_helper'
+
+describe FastJsonapi::ObjectSerializer do
+  class Vehicle
+    attr_accessor :id, :model, :year
+
+    def type
+      self.class.name.downcase
+    end
+  end
+
+  class Car < Vehicle
+    attr_accessor :purchased_at
+  end
+
+  class Bus < Vehicle
+    attr_accessor :passenger_count
+  end
+
+  class Truck < Vehicle
+    attr_accessor :load
+  end
+
+  class VehicleSerializer
+    include FastJsonapi::ObjectSerializer
+    attributes :model, :year
+  end
+
+  class CarSerializer < VehicleSerializer
+    attribute :purchased_at
+  end
+
+  class BusSerializer < VehicleSerializer
+    attribute :passenger_count
+  end
+
+  let(:car) do
+    car = Car.new
+    car.id = 1
+    car.model = 'Toyota Corolla'
+    car.year = 1987
+    car.purchased_at = Time.new(2018, 1, 1)
+    car
+  end
+
+  let(:bus) do
+    bus = Bus.new
+    bus.id = 2
+    bus.model = 'Nova Bus LFS'
+    bus.year = 2014
+    bus.passenger_count = 60
+    bus
+  end
+
+  let(:truck) do
+    truck = Truck.new
+    truck.id = 3
+    truck.model = 'Ford F150'
+    truck.year = 2000
+    truck
+  end
+
+  context 'when serializing a heterogenous collection' do
+    it 'should use the correct serializer for each item' do
+      vehicles = VehicleSerializer.new([car, bus], serializers: { Car: CarSerializer, Bus: BusSerializer }).to_hash
+      car, bus = vehicles[:data]
+
+      expect(car[:type]).to eq(:car)
+      expect(car[:attributes]).to eq(model: 'Toyota Corolla', year: 1987, purchased_at: Time.new(2018, 1, 1))
+
+      expect(bus[:type]).to eq(:bus)
+      expect(bus[:attributes]).to eq(model: 'Nova Bus LFS', year: 2014, passenger_count: 60)
+    end
+
+    context 'if there is no serializer given for the class' do
+      it 'should raise ArgumentError' do
+        expect { VehicleSerializer.new([truck], serializers: { Car: CarSerializer, Bus: BusSerializer }).to_hash }
+          .to raise_error(ArgumentError, 'no serializer defined for Truck')
+      end
+    end
+
+    context 'when given an empty set of serializers' do
+      it 'should use the serializer being called' do
+        data = VehicleSerializer.new([truck], serializers: {}).to_hash[:data][0]
+        expect(data[:type]).to eq(:vehicle)
+        expect(data[:attributes]).to eq(model: 'Ford F150', year: 2000)
+      end
+    end
+  end
+
+  context 'when serializing an arbitrary object' do
+    it 'should use the correct serializer' do
+      data = VehicleSerializer.new(car, serializers: { Car: CarSerializer, Bus: BusSerializer }).to_hash[:data]
+
+      expect(data[:type]).to eq(:car)
+      expect(data[:attributes]).to eq(model: 'Toyota Corolla', year: 1987, purchased_at: Time.new(2018, 1, 1))
+    end
+
+    context 'if there is no serializer given for the class' do
+      it 'should raise ArgumentError' do
+        expect { VehicleSerializer.new(truck, serializers: { Car: CarSerializer, Bus: BusSerializer }).to_hash }
+          .to raise_error(ArgumentError, 'no serializer defined for Truck')
+      end
+    end
+
+    context 'when given an empty set of serializers' do
+      it 'should use the serializer being called' do
+        data = VehicleSerializer.new(truck, serializers: {}).to_hash[:data]
+        expect(data[:type]).to eq(:vehicle)
+        expect(data[:attributes]).to eq(model: 'Ford F150', year: 2000)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Proposal for allowing for a heterogeneous collection (or a single item of unknown type) to be serialized in a single response.

I settled on injecting the serializers to use in the call rather than having more metadata inside the serializer itself. I think this makes it clearer what the intent is, and also doesn't pollute the serializer itself.

```ruby
VehicleSerializer.new(
  [car, bus],
  serializers: { Car: CarSerializer, Bus: BusSerializer }
)
```

I foresee using this with `ApplicationSerializer` or the like as a base class (this makes more semantic sense to me). I experimented a bit with adding a generic abstract serializer to use, but I don't know if that's appropriate for this change. Another way to do this that I like would be to have a static method on `ObjectSerializer`, such as: 

```ruby
FastJsonapi::ObjectSerializer.serialize(
  [car, bus],
  serializers: { Car: CarSerializer, Bus: BusSerializer }
)
```

but to do so we would need a base class to instantiate.

I welcome any feedback, especially in terms of the interface.

References #225, #393.