### PR TITLE
Map split include_item in-place

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,12 @@ rvm:
   - 2.3.6
   - 2.4.3
   - 2.5.0
+  - 2.6
+
+before_install:
+  - "travis_retry gem update --system 2.7.9"
+  - "travis_retry gem install bundler -v '1.17.3'"
+install: BUNDLER_VERSION=1.17.3 bundle install --path=vendor/bundle --retry=3 --jobs=3
+
 script:
   - bundle exec rspec

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -102,7 +102,8 @@ module FastJsonapi
 
       def parse_include_item(include_item)
         return [include_item.to_sym] unless include_item.to_s.include?('.')
-        include_item.to_s.split('.').map { |item| item.to_sym }
+
+        include_item.to_s.split('.').map!(&:to_sym)
       end
 
       def remaining_items(items)


### PR DESCRIPTION
```ruby
include_item = :'actors.agency.state'

ips benchmark:

Warming up --------------------------------------
            original    50.930k i/100ms
               patch    56.969k i/100ms
Calculating -------------------------------------
            original    657.066k (± 4.0%) i/s -      3.310M in   5.047973s
               patch    710.698k (± 2.0%) i/s -      3.589M in   5.052071s

Comparison:
               patch:   710698.3 i/s
            original:   657066.1 i/s - 1.08x  slower

memory benchmark:

Calculating -------------------------------------
            original   520.000  memsize (     0.000  retained)
                        13.000  objects (     0.000  retained)
                         4.000  strings (     0.000  retained)
               patch   480.000  memsize (     0.000  retained)
                        12.000  objects (     0.000  retained)
                         4.000  strings (     0.000  retained)

Comparison:
               patch:        480 allocated
            original:        520 allocated - 1.08x more
```