### PR TITLE
Include `data` key when lazy-loaded relationships are included

### DIFF
--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -43,7 +43,7 @@ module FastJsonapi
 
       return serializable_hash unless @resource
 
-      serializable_hash[:data] = self.class.record_hash(@resource, @fieldsets[self.class.record_type.to_sym], @params)
+      serializable_hash[:data] = self.class.record_hash(@resource, @fieldsets[self.class.record_type.to_sym], @includes, @params)
       serializable_hash[:included] = self.class.get_included_records(@resource, @includes, @known_included_objects, @fieldsets, @params) if @includes.present?
       serializable_hash
     end
@@ -55,7 +55,7 @@ module FastJsonapi
       included = []
       fieldset = @fieldsets[self.class.record_type.to_sym]
       @resource.each do |record|
-        data << self.class.record_hash(record, fieldset, @params)
+        data << self.class.record_hash(record, fieldset, @includes, @params)
         included.concat self.class.get_included_records(record, @includes, @known_included_objects, @fieldsets, @params) if @includes.present?
       end
 

--- a/lib/fast_jsonapi/relationship.rb
+++ b/lib/fast_jsonapi/relationship.rb
@@ -34,12 +34,12 @@ module FastJsonapi
       @lazy_load_data = lazy_load_data
     end
 
-    def serialize(record, serialization_params, output_hash)
+    def serialize(record, included, serialization_params, output_hash)
       if include_relationship?(record, serialization_params)
         empty_case = relationship_type == :has_many ? [] : nil
 
         output_hash[key] = {}
-        unless lazy_load_data
+        unless (lazy_load_data && !included)
           output_hash[key][:data] = ids_hash_from_record_and_relationship(record, serialization_params) || empty_case
         end
         add_links_hash(record, serialization_params, output_hash) if links.present?

--- a/spec/lib/object_serializer_relationship_links_spec.rb
+++ b/spec/lib/object_serializer_relationship_links_spec.rb
@@ -67,5 +67,23 @@ describe FastJsonapi::ObjectSerializer do
         expect(actor_hash).not_to have_key(:data)
       end
     end
+
+    context "included lazy loaded relationships" do
+      before(:context) do
+        class LazyLoadingMovieSerializer < MovieSerializer
+          has_many :actors, lazy_load_data: true, links: {
+            related: :actors_relationship_url
+          }
+        end
+      end
+
+      let(:serializer) { LazyLoadingMovieSerializer.new(movie, include: [:actors]) }
+      let(:actor_hash) { hash[:data][:relationships][:actors] }
+
+      it "includes the :data key" do
+        expect(actor_hash).to be_present
+        expect(actor_hash).to have_key(:data)
+      end
+    end
   end
 end

--- a/spec/lib/serialization_core_spec.rb
+++ b/spec/lib/serialization_core_spec.rb
@@ -52,7 +52,7 @@ describe FastJsonapi::ObjectSerializer do
     end
 
     it 'returns correct hash when record_hash is called' do
-      record_hash = MovieSerializer.send(:record_hash, movie, nil)
+      record_hash = MovieSerializer.send(:record_hash, movie, nil, nil)
       expect(record_hash[:id]).to eq movie.id.to_s
       expect(record_hash[:type]).to eq MovieSerializer.record_type
       expect(record_hash).to have_key(:attributes) if MovieSerializer.attributes_to_serialize.present?


### PR DESCRIPTION
Resolves #357 

When a relationship is listed under `include:`, it will add the data key to the record hash, allowing the included relationships to be reconstructed.