### PR TITLE
Allow relationship links to be declared as object method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,12 @@ rvm:
   - 2.3.6
   - 2.4.3
   - 2.5.0
+  - 2.6
+
+before_install:
+  - "travis_retry gem update --system 2.7.9"
+  - "travis_retry gem install bundler -v '1.17.3'"
+install: BUNDLER_VERSION=1.17.3 bundle install --path=vendor/bundle --retry=3 --jobs=3
+
 script:
   - bundle exec rspec

--- a/README.md
+++ b/README.md
@@ -277,6 +277,12 @@ class MovieSerializer
 end
 ```
 
+Relationship links can also be configured to be defined as a method on the object.
+
+```ruby
+  has_many :actors, links: :actor_relationship_links
+```
+
 This will create a `self` reference for the relationship, and a `related` link for loading the actors relationship later. NB: This will not automatically disable loading the data in the relationship, you'll need to do that using the `lazy_load_data` option:
 
 ```ruby

--- a/lib/fast_jsonapi/relationship.rb
+++ b/lib/fast_jsonapi/relationship.rb
@@ -104,8 +104,12 @@ module FastJsonapi
     end
 
     def add_links_hash(record, params, output_hash)
-      output_hash[key][:links] = links.each_with_object({}) do |(key, method), hash|
-        Link.new(key: key, method: method).serialize(record, params, hash)\
+      if links.is_a?(Symbol)
+        output_hash[key][:links] = record.public_send(links)
+      else
+        output_hash[key][:links] = links.each_with_object({}) do |(key, method), hash|
+          Link.new(key: key, method: method).serialize(record, params, hash)\
+        end
       end
     end
 

--- a/spec/lib/object_serializer_relationship_links_spec.rb
+++ b/spec/lib/object_serializer_relationship_links_spec.rb
@@ -67,5 +67,28 @@ describe FastJsonapi::ObjectSerializer do
         expect(actor_hash).not_to have_key(:data)
       end
     end
+
+    context "relationship links defined by a method on the object" do
+      before(:context) do
+        class Movie
+          def relationship_links
+            { self: "http://movies.com/#{id}/relationships/actors" }
+          end
+        end
+
+        class LinksPassingMovieSerializer < MovieSerializer
+          has_many :actors, links: :relationship_links
+        end
+      end
+
+      let(:serializer) { LinksPassingMovieSerializer.new(movie) }
+      let(:links) { hash[:data][:relationships][:actors][:links] }
+      let(:relationship_url) { "http://movies.com/#{movie.id}/relationships/actors" }
+
+      it "generates relationship links in the object" do
+        expect(links).to be_present
+        expect(links[:self]).to eq(relationship_url)
+      end
+    end
   end
 end


### PR DESCRIPTION
Allow the definition of links on relationships to be declared as a method on the object.

For example:
```ruby
# actor_relationship_links is a method on the object being serialized.
has_many :actors, links: :actor_relationship_links 
```