### PR TITLE
Vim wouldn't save this file because ruby linting found a trailing backslash

### DIFF
--- a/lib/fast_jsonapi/relationship.rb
+++ b/lib/fast_jsonapi/relationship.rb
@@ -105,7 +105,7 @@ module FastJsonapi
 
     def add_links_hash(record, params, output_hash)
       output_hash[key][:links] = links.each_with_object({}) do |(key, method), hash|
-        Link.new(key: key, method: method).serialize(record, params, hash)\
+        Link.new(key: key, method: method).serialize(record, params, hash)
       end
     end
 


### PR DESCRIPTION
Is this correct to remove? Was it intentional? Apologies if so - never have seen that in my years of ruby, so figured it was an accident.