### PR TITLE
Keep namespace in record_type

### DIFF
--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -131,7 +131,7 @@ module FastJsonapi
 
         @reflected_record_type ||= begin
           if self.name && self.name.end_with?('Serializer')
-            self.name.split('::').last.chomp('Serializer').underscore.to_sym
+            self.name.split('::').join('_').chomp('Serializer').underscore.to_sym
           end
         end
       end

--- a/spec/lib/object_serializer_spec.rb
+++ b/spec/lib/object_serializer_spec.rb
@@ -335,7 +335,7 @@ describe FastJsonapi::ObjectSerializer do
           include FastJsonapi::ObjectSerializer
         end
       end
-      expect(V1::BlahSerializer.record_type).to be :blah
+      expect(V1::BlahSerializer.record_type).to be :v1_blah
     end
 
     it 'shouldnt set default_type for a serializer that doesnt follow convention' do


### PR DESCRIPTION
Hi,
this PR is about to keep the namespace in `record_type`. I believe it should be like this because the namespace is an important part of the class name and without it the record_type is not assured to be unique like it's supposed to be.
We intensively use namespace and we have a few classes with the same name in different namespace and so it can create some confusion for our frontend developers.

I think it should at least be a global option, and I don't want to set `set_type` on every serializer and `record_type` on every relation (by the way it's strange to have to set again `record_type` on relations).