### PR TITLE
Support custom id methods for polymorphic relationships

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,9 +579,3 @@ To run tests only performance tests:
 ```bash
 rspec spec --tag performance:true
 ```
-
-### We're Hiring!
-
-Join the Netflix Studio Engineering team and help us build gems like this!
-
-* [Senior Ruby Engineer](https://jobs.netflix.com/jobs/864893)

--- a/README.md
+++ b/README.md
@@ -276,7 +276,12 @@ This will create a `self` reference for the relationship, and a `related` link f
 ### Meta Per Resource
 
 For every resource in the collection, you can include a meta object containing non-standard meta-information about a resource that can not be represented as an attribute or relationship.
+
+
 ```ruby
+class MovieSerializer
+  include FastJsonapi::ObjectSerializer
+
   meta do |movie|
     {
       years_since_release: Date.current.year - movie.year

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Fast JSON API serialized 250 records in 3.01 ms
   * [Conditional Attributes](#conditional-attributes)
   * [Conditional Relationships](#conditional-relationships)
   * [Sparse Fieldsets](#sparse-fieldsets)
+  * [Using helper methods](#using-helper-methods)
 * [Contributing](#contributing)
 
 
@@ -447,6 +448,68 @@ end
 
 serializer = MovieSerializer.new(movie, { fields: { movie: [:name] } })
 serializer.serializable_hash
+```
+
+### Using helper methods
+
+You can mix-in code from another ruby module into your serializer class to reuse functions across your app.
+
+Since a serializer is evaluated in a the context of a `class` rather than an `instance` of a class, you need to make sure that your methods act as `class` methods when mixed in.
+
+
+##### Using ActiveSupport::Concern
+
+``` ruby
+
+module AvatarHelper
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def avatar_url(user)
+      user.image.url
+    end
+  end
+end
+
+class UserSerializer
+  include FastJsonapi::ObjectSerializer
+
+  include AvatarHelper # mixes in your helper method as class method
+
+  set_type :user
+
+  attributes :name, :email
+
+  attribute :avatar do |user|
+    avatar_url(user)
+  end
+end
+
+```
+
+##### Using Plain Old Ruby
+
+``` ruby
+module AvatarHelper
+  def avatar_url(user)
+    user.image.url
+  end
+end
+
+class UserSerializer
+  include FastJsonapi::ObjectSerializer
+
+  extend AvatarHelper # mixes in your helper method as class method
+
+  set_type :user
+
+  attributes :name, :email
+
+  attribute :avatar do |user|
+    avatar_url(user)
+  end
+end
+
 ```
 
 ### Customizable Options

--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -241,12 +241,15 @@ module FastJsonapi
           base_key_sym = name
           id_postfix = '_id'
         end
+        polymorphic = fetch_polymorphic_option(options)
+
         Relationship.new(
           key: options[:key] || run_key_transform(base_key),
           name: name,
           id_method_name: compute_id_method_name(
             options[:id_method_name],
             "#{base_serialization_key}#{id_postfix}".to_sym,
+            polymorphic,
             block
           ),
           record_type: options[:record_type] || run_key_transform(base_key_sym),
@@ -255,7 +258,7 @@ module FastJsonapi
           serializer: compute_serializer_name(options[:serializer] || base_key_sym),
           relationship_type: relationship_type,
           cached: options[:cached],
-          polymorphic: fetch_polymorphic_option(options),
+          polymorphic: polymorphic,
           conditional_proc: options[:if],
           transform_method: @transform_method,
           links: options[:links],
@@ -263,8 +266,8 @@ module FastJsonapi
         )
       end
 
-      def compute_id_method_name(custom_id_method_name, id_method_name_from_relationship, block)
-        if block.present?
+      def compute_id_method_name(custom_id_method_name, id_method_name_from_relationship, polymorphic, block)
+        if block.present? || polymorphic
           custom_id_method_name || :id
         else
           custom_id_method_name || id_method_name_from_relationship

--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -124,6 +124,7 @@ module FastJsonapi
         subclass.cached = cached
         subclass.set_type(subclass.reflected_record_type) if subclass.reflected_record_type
         subclass.meta_to_serialize = meta_to_serialize
+        subclass.record_id = record_id
       end
 
       def reflected_record_type

--- a/lib/fast_jsonapi/relationship.rb
+++ b/lib/fast_jsonapi/relationship.rb
@@ -78,7 +78,7 @@ module FastJsonapi
     def id_hash_from_record(record, record_types)
       # memoize the record type within the record_types dictionary, then assigning to record_type:
       associated_record_type = record_types[record.class] ||= run_key_transform(record.class.name.demodulize.underscore)
-      id_hash(record.id, associated_record_type)
+      id_hash(record.public_send(id_method_name), associated_record_type)
     end
 
     def ids_hash(ids)


### PR DESCRIPTION
For polymorphic has_many relations, instead of getting the ids in a batch, the code loops over each object to get its type and id. In `Relationship#id_hash_from_record` it was hardcoded to get the id by calling `record.id`, which overrides the `id_method_name` options passed into the relationship.

I tried fixing this by only changing the code in `Relationship` to dynamically call the `id_method_name` on the object, but unfortunately on has_many relationships the default value for `id_method_name` would be passed as if the ids would be pulled in a batch (for example `groupee_ids`). That default works for regular has_manys where we get the ids all at once but fails for polymorphic ones where it loops over each object.

So, fixing the problem required passing the polymorphic information to `compute_id_method_name`, which now defaults to `id` rather than `id_method_name_from_relationship` in the case where the relationship is polymorphic.