### PR TITLE
Fix Travis CI build by allowing newer Bundler versions

### DIFF
--- a/fast_jsonapi.gemspec
+++ b/fast_jsonapi.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency(%q<rspec>, ["~> 3.5.0"])
   gem.add_development_dependency(%q<oj>, ["~> 3.3"])
   gem.add_development_dependency(%q<rspec-benchmark>, ["~> 0.3.0"])
-  gem.add_development_dependency(%q<bundler>, ["~> 1.0"])
+  gem.add_development_dependency(%q<bundler>, [">= 1.0"])
   gem.add_development_dependency(%q<byebug>, [">= 0"])
   gem.add_development_dependency(%q<active_model_serializers>, ["~> 0.10.7"])
   gem.add_development_dependency(%q<sqlite3>, ["~> 1.3"])


### PR DESCRIPTION
The Travis CI build currently fails because it's trying to use a newer version of Bundler which is disallowed by the `fast_jsonapi.gemspec` file.

This is an attempt to fix the builds by allowing for these newer Bundlers.